### PR TITLE
Incorporate SecureDrop Workstation developer docs from README

### DIFF
--- a/docs/development/client.rst
+++ b/docs/development/client.rst
@@ -1,5 +1,5 @@
-Developing the SecureDrop Client Application
-============================================
+SecureDrop Client Development
+=============================
 
 As part of the ongoing work to make an integrated journalist-friendly workstation
 for SecureDrop we have created a native client application to be run within the

--- a/docs/development/workstation_development.rst
+++ b/docs/development/workstation_development.rst
@@ -1,0 +1,113 @@
+SecureDrop Workstation Development
+==================================
+
+This project’s development requires different workflows for working on
+provisioning components and working on submission-handling scripts.
+
+For developing salt states and other provisioning components, work is
+done in a development VM and changes are made to individual state and
+top files there. In the ``dom0`` copy of this project: - ``make clone``
+is used to build a new version of the RPM and copy the contents of your
+working directory (including the RPM) from your development VM to
+``dom0`` - ``make <vm-name>`` can be used to rebuild an individual VM -
+``make dev`` installs the latest locally present RPM and performs the
+full installation.
+
+Note that ``make clone`` requires two environment variables to be set:
+``SECUREDROP_DEV_VM`` must be set to the name of the VM where you’ve
+been working on the code, the ``SECUREDROP_DEV_DIR`` should be set to
+the directory where the code is checked out on your development VM.
+
+For work on components such as the SecureDrop Client, see their
+respective repositories for developer documentation.
+
+Testing
+-------
+
+Tests should cover two broad domains. First, we should assert that all
+the expected VMs exist and are configured as we expect (with the correct
+NetVM, with the expected files in the correct place). Second, we should
+end-to-end test the document handling scripts, asserting that files
+present in the ``sd-proxy`` VM correctly make their way to the
+``sd-app`` AppVM, and are opened correctly in disposable VMs.
+
+Configuration Tests
+~~~~~~~~~~~~~~~~~~~
+
+These tests assert that expected scripts and configuration files are in
+the correct places across the VMs. These tests can be found in the
+``tests/`` directory. They can be run from the project’s root directory
+on ``dom0`` with:
+
+::
+
+   make test
+
+Note that since tests confirm the states of provisioned VMs, they should
+be run *after* all the VMs have been built with ``make dev``.
+
+Individual tests can be run with ``make <test-name>``, where
+``test-name`` is one of ``test-base``, ``test-app``, ``test-proxy``,
+``test-whonix`` or ``test-gpg``.
+
+Be aware that running tests *will* power down running SecureDrop VMs,
+and may result in *data loss*. Only run tests in a development / testing
+environment.
+
+Automatic updates
+-----------------
+
+Double-clicking the “SecureDrop” desktop icon will launch a preflight
+updater that applies any necessary updates to VMs, and may prompt a
+reboot. In a development environment, this will install the latest
+nightly packages, and the latest RPM published to ``yum-test``.
+
+Manually updating dom0 code
+---------------------------
+
+To update code in ``dom0`` manually, e.g., to a specific branch or tag
+of this repository, use the ``sd-dev`` AppVM that was created during the
+install. For example, to build a specific tag, from your checkout
+directory, run the following commands (replace ``<tag>`` with the tag of
+the release you are working with):
+
+::
+
+   git fetch --tags
+   git tag -v <tag>
+   git checkout <tag>
+
+In ``dom0``:
+
+::
+
+   make clone
+   make dev
+
+The ``make clone`` command will build a new version of the RPM package
+that contains the provisioning logic in your development VM (e.g.,
+``sd-dev``) and copy it to ``dom0``.
+
+Building the Templates
+----------------------
+
+To build the base template, please follow the instructions in
+https://github.com/freedomofpress/qubes-template-securedrop-workstation
+
+Building workstation deb packages
+---------------------------------
+
+Debian packages for the SecureDrop Workstation components are maintained
+in a separate repository:
+https://github.com/freedomofpress/securedrop-debian-packaging/
+
+Building workstation rpm packages
+---------------------------------
+
+::
+
+   make dom0-rpm
+
+The build assumes use of Debian Stable as the build environment. You can
+install the necessary dependencies from system packages via the
+``make install-deps`` target.

--- a/docs/development/workstation_release_management.rst
+++ b/docs/development/workstation_release_management.rst
@@ -1,0 +1,340 @@
+Releasing SecureDrop Workstation and its Subprojects
+====================================================
+
+Release a subproject
+--------------------
+
+SecureDrop Workstation code spans across several repositories:
+
+-  https://github.com/freedomofpress/securedrop-client (Debian packaged)
+-  https://github.com/freedomofpress/securedrop-export (Debian packaged)
+-  https://github.com/freedomofpress/securedrop-log (Debian packaged)
+-  https://github.com/freedomofpress/securedrop-proxy (Debian packaged)
+-  https://github.com/freedomofpress/securedrop-sdk (Python packaged,
+   brought in as a dependency of ``securedrop-client``)
+-  https://github.com/freedomofpress/securedrop-workstation (RPM
+   packaged)
+
+Some of these subprojects have a corresponding release guide in the
+project’s README
+(`example <https://github.com/freedomofpress/securedrop-client#making-a-release>`__
+for ``securedrop-client``). The release process for each subproject is
+generally:
+
+1. Run that project’s update version script if it has one. Else, update
+   version numbers manually. Update the changelog describing the changes
+   in that release.
+2. Commit those changes, and create a PR.
+3. Once this PR is approved, add a tag (see below) that is signed with
+   the official release key.
+
+**Note:** Early tags in each subproject were not signed with the
+official release key. Later releases, as the subprojects were prepared
+for production, had their tags signed with the official release key.
+
+In addition, we have the following (Debian) metapackages, which are
+stored in the
+`securedrop-debian-packaging <https://github.com/freedomofpress/securedrop-debian-packaging>`__
+repository: \*
+```securedrop-workstation-config`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/master/securedrop-workstation-config/debian>`__
+\*
+```securedrop-workstation-grsec`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/master/securedrop-workstation-grsec>`__
+\*
+```securedrop-workstation-viewer`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/master/securedrop-workstation-viewer>`__
+
+The release process for a metapackage is generally to bump the version,
+update the debian changelog, and then tag
+``securedrop-debian-packaging`` (see below).
+
+Each subcomponent can be released independently. It’s worth noting that
+in general ``securedrop-sdk`` releases generally be accompanied with a
+``securedrop-client`` release, as ``securedrop-sdk`` is a Python
+dependency of the ``securedrop-client`` code, so any change in the SDK
+the client wants to use will necessitate a release of the client also.
+We’ll cover that below.
+
+Tag a subproject
+----------------
+
+Once the release PR is merged, the procedure of adding signed tags is as
+follows:
+
+1.  Create tag: ``git tag -a VERSION``
+2.  Output tag to file: ``git cat-file tag VERSION > VERSION.tag``
+3.  Copy tag file to signing environment
+4.  Verify tag integrity (commit hash)
+5.  Sign tag with release key: ``gpg --armor --detach-sign VERSION.tag``
+6.  Append ASCII-armored signature to tag file (ensure there are no
+    blank lines): ``cat VERSION.tag.sig >> VERSION.tag``
+7.  Move tag file with signature appended back to the release
+    environment
+8.  Delete old (unsigned) tag: ``git tag -d VERSION``
+9.  Create new (signed) tag:
+    ``git mktag < VERSION.tag > .git/refs/tags/VERSION``
+10. Verify the tag: ``git tag -v VERSION``
+11. Push the tag to the shared remote: ``git push origin VERSION``
+
+Generate Tarballs
+-----------------
+
+Next, for the Debian-packaged projects **only**, one needs to generate
+the source tarballs for use during packaging, as well as add the debian
+changelog addition. This is done via a PR into
+https://github.com/freedomofpress/securedrop-debian-packaging.
+
+Follow the instructions described in `this
+section <https://github.com/freedomofpress/securedrop-debian-packaging#build-a-package>`__,
+stopping before the final step where the package itself is built. Save
+the build logs from the tarball generation step (since the tarball
+generation is not reproducible) and commit them
+`here <https://github.com/freedomofpress/build-logs>`__. You should then
+in a branch:
+
+-  Add the tarball that is generated from that step to the
+   ``./tarballs`` directory in that
+   `securedrop-debian-packaging <https://github.com/freedomofpress/securedrop-debian-packaging>`__
+   repository
+-  Add a detached signature of that tarball also to the ``./tarballs``
+   directory alongside the tarball above for ease of verification
+-  Add the Debian changelog addition
+-  Remove the tarball and corresponding signature from the previous
+   release.
+
+File that PR. Once it’s approved, move to the next step.
+
+Tag code used to generate artifacts
+-----------------------------------
+
+In addition to the code repositories above, the following repositories
+are used to create artifacts - the ``securedrop-workstation`` template
+and the debian packages, respectively - used in the workstation:
+
+-  https://github.com/freedomofpress/qubes-template-securedrop-workstation
+-  https://github.com/freedomofpress/securedrop-debian-packaging
+
+Next, if one of these projects is needed to generate an artifact for us
+in a production environment, it will be released by adding a signed tag
+before using the corresponding logic. You can do this following the same
+steps as in the ``Tag a subproject`` section. For
+``securedrop-debian-packaging``, we include in the tag annotation the
+latest release for each subproject that is released using its logic. For
+example the tag annotation for ``securedrop-debian-packaging 0.2.2``:
+
+::
+
+   securedrop-client 0.1.2
+   securedrop-proxy 0.2.0
+   securedrop-log 0.1.0
+   securedrop-export 0.2.1
+   securedrop-workstation-svs-disp 0.2.1
+   securedrop-workstation-grsec 4.14.169
+   securedrop-workstation-config 0.1.2
+
+Final build for a subproject
+----------------------------
+
+Finally, perform the final build. You should follow one of the sections
+below based on whether the subproject you are building is Debian or rpm
+packaged.
+
+Debian package
+~~~~~~~~~~~~~~
+
+In an environment sufficient for building production artifacts (if
+unsure, check with a technical lead):
+
+1. Clone the
+   `securedrop-debian-packaging <https://github.com/freedomofpress/securedrop-debian-packaging>`__
+   repository.
+2. Determine which version of the packaging logic and tarballs you want
+   to use. You probably created the tag in the previous step, else
+   inspect the tag annotation to determine which is the right version.
+3. ``git tag -v VERSION`` and ensure the tag is signed with the official
+   release key.
+4. ``git checkout VERSION``
+5. Now you are ready to build. For good measure, you can also verify the
+   signature of the tarball you want to use, although this will have
+   been done by the reviewer of the PR adding the tarball.
+6. Set ``PKG_DIR`` to point to the tarball you wish to package, and
+   ``PKG_VERSION`` to the version you wish to package, then run the
+   relevant makefile target in the
+   `securedrop-debian-packaging <https://github.com/freedomofpress/securedrop-debian-packaging>`__
+   repository. For example to build version 0.1.1 of the
+   ``securedrop-client``:
+
+``$ PKG_VERSION=0.1.1 PKG_PATH=tarballs/securedrop-client-0.1.1.tar.gz make securedrop-client``
+
+6.  Upload build logs in the
+    `build-logs <https://github.com/freedomofpress/build-logs>`__
+    repository in the workstation directory. Ensure that the sha256sum
+    of the built package is included in the build log.
+7.  Next, add the package via PR to the private
+    `securedrop-debian-packages-lfs <https://github.com/freedomofpress/securedrop-debian-packages-lfs>`__
+    repository.
+8.  Regenerate reprepro repository metadata using the script in that
+    repository: ``./tools/publish``. When you inspect the diff, you’ll
+    notice that the previous version of the subproject will no longer be
+    served. This is expected.
+9.  Copy the ``Release`` file to signing environment.
+10. Verify integrity of ``Release`` file.
+11. Sign the Release file
+    ``gpg --armor --detach-sign --output Release.gpg Release``
+12. Copy the detached signature into your working directory and commit
+    along with the new package(s), and the modified repository metadata.
+13. Open a PR for review.
+14. Upon merge to master, ensure that changes deploy to
+    ``apt.freedom.press`` without issue.
+
+RPM package
+~~~~~~~~~~~
+
+1.  Verify the tag of the project you wish to build:
+    ``git tag -v VERSION`` and ensure the tag is signed with the
+    official release key.
+2.  ``git checkout VERSION``
+3.  Now you are ready to build. Build RPMs following the documentation
+    in an environment sufficient for building production artifacts. For
+    ``securedrop-workstation`` you run ``make dom0-rpm`` to build the
+    RPM.
+4.  sha256sum the built template (and store hash in the build
+    logs/commit message).
+5.  Commit the (unsigned) version of this RPM to a branch in the
+    `securedrop-workstation-prod-rpm-packages-lfs <https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs>`__
+    repository.
+6.  Copy the RPM to the signing environment.
+7.  Verify integrity of RPM prior to signing (use sha256sums to
+    compare). **Note for reviewers:** Using ``rpm --delsign`` on a
+    signed artifact (for example, a release candidate) in order to
+    verify the checksum of the unsigned .rpm file must be done in the
+    same type of build environment (Linux distribution and ``rpm``
+    version) as the .rpm was built in, or the checksums may not match.
+8.  Sign RPM in place (see Signing section below).
+9.  Move the signed RPM back to the environment for committing to the
+    lfs repository.
+10. Upload build logs directly to the
+    `build-logs <https://github.com/freedomofpress/build-logs>`__
+    repository in the workstation directory. Ensure that the sha256sum
+    of the package before and after signing is included in the build
+    log.
+11. Commit the RPM in a second commit on the branch you began above in
+    `securedrop-workstation-prod-rpm-packages-lfs <https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs>`__.
+    Make a PR.
+12. Upon merge to master, ensure that changes deploy to
+    ``yum.securedrop.org`` without issue.
+
+``qubes-template-securedrop-workstation`` release and promotion to production
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SecureDrop workstation template is RPM packaged, and is first
+deployed to ``yum-test.securedrop.org`` before being promoted to
+production (``yum.securedrop.org``) using the following procedure:
+
+1.  Verify the tag in the
+    `qubes-template-securedrop-workstation <https://github.com/freedomofpress/qubes-template-securedrop-workstation>`__
+    repository: ``git tag -v VERSION`` and ensure the tag is signed with
+    the official release key.
+2.  ``git checkout VERSION``
+3.  Rebuild template following documentation in
+    `qubes-template-securedrop-workstation <https://github.com/freedomofpress/qubes-template-securedrop-workstation>`__.
+4.  sha256sum the built template (and store hash in the build
+    logs/commit message).
+5.  Commit unsigned template for historical purposes.
+6.  Sign template RPM with test key (rpm –resign ) (see Signing section
+    below).
+7.  Commit signed template.
+8.  Push those two commits to a PR in
+    `securedrop-workstation-dev-rpm-packages-lfs <https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/>`__.
+    Make the PR.
+9.  Upload build logs directly to the
+    `build-logs <https://github.com/freedomofpress/build-logs>`__
+    repository in the workstation directory.
+10. Upon merge of the PR into
+    `securedrop-workstation-dev-rpm-packages-lfs <https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/>`__,
+    the template will be deployed to ``yum-test.securedrop.org``.
+11. Test template.
+12. Once template is sufficiently tested, remove test sig:
+    ``rpm --delsign <file>``.
+13. Verify unsigned template sha256sum from build logs/commit message.
+14. Sign template with prod key: ``rpm --resign <file>``
+15. Push commit to a branch in the
+    `securedrop-workstation-prod-rpm-packages-lfs <https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/>`__
+    repository. Make a PR.
+16. Upon merge to master, ensure that changes deploy to
+    ``yum.securedrop.org`` without issue.
+
+Signing binaries/packages
+-------------------------
+
+Debian packages
+~~~~~~~~~~~~~~~
+
+The apt repository Release file will be signed, containing checksums of
+the debs.
+
+RPM packages
+~~~~~~~~~~~~
+
+The entire RPM must be signed. This process also requires a Fedora
+machine/VM on which the GPG signing key (either in GPG keyring or in
+qubes-split-gpg) is setup. You will need to add the public key to RPM
+for verification (see below).
+
+``rpm -Kv`` indicates if digests and sigs are OK. Before signature it
+should not return signature, and ``rpm -qi <file>.rpm`` will indicate an
+empty Signature field. Set up your environment (for prod you can use the
+``~/.rpmmacros`` example file at the bottom of this section):
+
+::
+
+   sudo dnf install rpm-build rpm-sign  # install required packages
+   echo "vault" | sudo tee /rw/config/gpg-split-domain  # edit 'vault' as required
+   cat << EOF > ~/.rpmmacros
+   %_signature gpg
+   %_gpg_name <gpg_key_id>
+   %__gpg /usr/bin/qubes-gpg-client-wrapper
+   %__gpg_sign_cmd %{__gpg} --no-verbose -u %{_gpg_name} --detach-sign %{__plaintext_filename} --output %{__signature_filename}
+   EOF
+
+Now we’ll sign the RPM:
+
+::
+
+   rpm --resign <rpm>.rpm  # --addsign would allow us to apply multiple signatures to the RPM
+   rpm -qi<file.rpm>  # should now show that the file is signed
+   rpm -Kv  # should contain NOKEY errors in the lines containing Signature
+   # This is because the the (public) key of the RPM signing key is not present,
+   # and must be added to the RPM client config to verify the signature:
+   sudo rpm --import <publicKey>.asc
+   rpm -Kv  # Signature lines will now contain OK instead of NOKEY
+
+You can then proceed with distributing the package, via the “test” or
+“prod” repo, as appropriate.
+
+``~/.rpmmacros`` file
+~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+   %_signature gpg
+   %_gpg_name 22245C81E3BAEB4138B36061310F561200F4AD77
+
+Distributing packages
+---------------------
+
+For the Debian packages, see
+https://github.com/freedomofpress/securedrop-debian-packaging/. For the
+RPM packages, such as the ``securedrop-workstation`` TemplateVM package,
+first build the package (e.g. ``make template``), then sign the RPM, as
+outlined above.
+
+To upload the package, submit a PR to
+https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/
+
+The RPM will immediately be available in dom0. Provided you’ve run the
+Salt configurations, find it via:
+
+::
+
+   sudo qubes-dom0-update --action=search qubes-template-securedrop-workstation
+
+You can then install it directly.

--- a/docs/development/workstation_setup.rst
+++ b/docs/development/workstation_setup.rst
@@ -104,13 +104,7 @@ Next we need to do some SecureDrop-specific configuration:
 Qubes provisioning is handled by Salt on ``dom0``, so this project must
 be copied there from your development VM.
 
-.. note::
-
-    Understand that `copying data to dom0 <https://www.qubes-os.org/doc/copy-from-dom0/#copying-to-dom0>`__ goes
-    against the grain of the Qubes security philosophy, and should only done
-    with trusted code and for very specific purposes, such as Qubes-related
-    development tasks. Still, be aware of the risks, especially if you rely
-    on your Qubes installation for other sensitive work.
+.. include:: ../includes/dom0-warning.txt
 
 That process is a little tricky, but here’s one way to do it: assuming
 this code is checked out in your ``sd-dev`` VM at
@@ -285,12 +279,7 @@ as follows:
 
 5. Transfer and install RPM package in ``dom0``
 
-*Understand that*\ `copying data to
-dom0 <https://www.qubes-os.org/doc/copy-from-dom0/#copying-to-dom0>`__\ *goes
-against the grain of the Qubes security philosophy, and should only done
-with trusted code and for very specific purposes. Still, be aware of the
-risks, especially if you rely on your Qubes installation for other
-sensitive work.*
+.. include:: ../includes/dom0-warning.txt
 
 In ``dom0``, run the following commands (changing the version number to
 its current value):

--- a/docs/development/workstation_setup.rst
+++ b/docs/development/workstation_setup.rst
@@ -1,0 +1,326 @@
+Setting up the SecureDrop Workstation
+=====================================
+The SecureDrop Workstation based on `Qubes OS <https://www.qubes-os.org/>`_
+is a project currently in the beta stages of software development which aims to
+improve journalists' experience working with SecureDrop while retaining
+the current security and privacy features SecureDrop provides.
+
+Installing the project requires an up-to-date Qubes 4.1 installation
+running on a machine with at least 16GB of RAM (32 GB recommended).
+You'll need access to a SecureDrop staging server as well.
+
+The project is currently in a closed beta, and we do not recommend
+installing it for production purposes. Documentation for end users is
+being developed `here <https://workstation.securedrop.org>`__. The
+instructions below are intended for developers.
+
+Install Qubes
+-------------
+
+Before trying to use this project, install `Qubes
+4.1.1 <https://www.qubes-os.org/downloads/>`__ on your development
+machine. Accept the default VM configuration during the install process.
+
+After installing Qubes, you must update both dom0 and the base templates
+to include the latest versions of apt packages. Open a terminal in
+``dom0`` by clicking on the Qubes menu top-right of the screen and
+left-clicking on Terminal Emulator and run:
+
+::
+
+   sudo qubes-dom0-update
+
+After dom0 updates complete, reboot your computer to ensure the updates
+have been properly applied. Finally, update all existing TemplateVMs:
+
+::
+
+   qubes-update-gui
+
+Select all VMs marked as **updates available**, then click **Next**.
+Once all updates have been applied, you’re ready to proceed. Choose the
+environment that you wish to set up and then follow the applicable
+instructions:
+
+-  The staging environment uses the ``yum-test.securedrop.org`` and
+   ``apt-test.freedom.press`` repositories, and is configured to use the
+   ``main`` component for apt packages. It will typically install the
+   most recent release candidate packages (which could be more recent
+   than the production packages if a release is underway).
+
+-  The development environment uses the ``yum-test.securedrop.org`` and
+   ``apt-test.freedom.press`` repositories, and is configured to use the
+   ``nightly`` component for apt package. It does not alter power
+   management settings on your laptop to prevent suspension to disk (a
+   security measure for production environments, which the staging
+   environment preserves to be more faithful to prod-like settings).
+
+-  The production environment uses ``yum.securedrop.org`` and
+   ``apt.freedom.press`` repositories, verified using the production
+   signing key. Its setup is not covered below; see our `production
+   install
+   docs <https://workstation.securedrop.org/en/stable/admin/install.html>`__
+   for details.
+
+Development Environment
+-----------------------
+
+Download, Configure, Copy to ``dom0``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This repository contains the specification for an RPM package, which
+contains the provisioning logic. By following the instructions below,
+you will build this RPM package locally from a ``git`` checkout in your
+development VM, copy it to ``dom0``, install it, and run the
+provisioning code to set up a SecureDrop Workstation in the development
+environment configuration.
+
+Decide on a VM to use for development. We recommend creating a
+standalone VM called ``sd-dev`` by following `these
+instructions <https://docs.securedrop.org/en/stable/development/setup_development.html#qubes>`__.
+
+Clone this repo to your preferred location on that VM.
+
+Next we need to do some SecureDrop-specific configuration:
+
+-  Create a ``config.json`` file based on ``config.json.example`` and
+   include your values for the hidserv fields: ``hostname`` (the
+   Journalist Interface Onion URL) and ``key`` (the private key for
+   client authentication). Set ``submission_key_fpr`` to the submission
+   key fingerprint.
+
+   -  On your Admin Workstation, you can find the Journalist Interface
+      onion address and private key in
+      ``~/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private``,
+      and the submission key fingerprint in
+      ``~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific``
+      (``securedrop_app_gpg_fingerprint``).
+
+-  Create an ``sd-journalist.sec`` file in the root directory with the
+   ASCII-armored GPG private key used to encrypt submissions in your
+   test SecureDrop instance. The included key ``sd-journalist.sec`` is
+   the one used by default in the SecureDrop staging instance.
+
+Qubes provisioning is handled by Salt on ``dom0``, so this project must
+be copied there from your development VM.
+
+.. note::
+
+    Understand that `copying data to dom0 <https://www.qubes-os.org/doc/copy-from-dom0/#copying-to-dom0>`__ goes
+    against the grain of the Qubes security philosophy, and should only done
+    with trusted code and for very specific purposes, such as Qubes-related
+    development tasks. Still, be aware of the risks, especially if you rely
+    on your Qubes installation for other sensitive work.
+
+That process is a little tricky, but here’s one way to do it: assuming
+this code is checked out in your ``sd-dev`` VM at
+``/home/user/projects/securedrop-workstation``, run the following in
+``dom0``:
+
+::
+
+   qvm-run --pass-io sd-dev 'tar -c -C /home/user/projects/ securedrop-workstation' | tar xvf -
+
+(Be sure to include the space after ``/home/user/projects/``.) After
+that initial manual step, the code in your development VM may be copied
+into place on ``dom0`` by setting the ``SECUREDROP_DEV_VM`` and
+``SECUREDROP_DEV_DIR`` environmental variables to reflect the VM and
+directory to which you’ve cloned this repo, and running ``make clone``
+from the root of the project on ``dom0``:
+
+::
+
+   [dom0]$ export SECUREDROP_DEV_VM=sd-dev    # set to your dev VM
+   [dom0]$ export SECUREDROP_DEV_DIR=/home/user/projects/securedrop-workstation    # set to your working directory
+   [dom0]$ cd ~/securedrop-workstation/
+   [dom0]$ make clone    # build RPM package and copy repo to dom0
+
+**NOTE:** The destination directory on ``dom0`` is not customizable; it
+must be ``securedrop-workstation`` in your home directory.
+
+If you plan to work on the `SecureDrop
+Client <https://github.com/freedomofpress/securedrop-client>`__ code,
+also run this command in ``dom0``:
+
+::
+
+   qvm-tags sd-dev add sd-client
+
+Doing so will permit the ``sd-dev`` AppVM to make RPC calls with the
+same privileges as the ``sd-app`` AppVM.
+
+Provision the VMs
+~~~~~~~~~~~~~~~~~
+
+Once the configuration is done and this directory is copied to ``dom0``,
+you must update existing Qubes templates and use ``make`` to handle all
+provisioning and configuration by your unprivileged user. Before you do
+so, you may wish to increase the scrollback in the dom0 terminal from
+1000 (the default) to 100000 or unlimited, to ensure you can review any
+errors in the verbose output.
+
+Then run the following command to set up a development environment:
+
+::
+
+   make dev
+
+Note that this target automatically sets the ``environment`` variable in
+``config.json`` to ``dev``, regardless of its current value, before
+provisioning. It identifies the latest RPM you have built (using
+``scripts/prep-dev``), installs it, and runs the ``sdw-admin --apply``
+command to provision the SecureDrop Workstation.
+
+The build process takes quite a while. You will be presented with a
+dialog asking how to connect to Tor: you should be able to select the
+default option and continue. If you want to refer back to the
+provisioning log for a given VM, go to
+``/var/log/qubes/mgmt-<vm name>.log`` in ``dom0``. You can also monitor
+logs as they’re being written via ``journalctl -ef``. This will display
+logs across the entire system so it can be noisy. It’s best used when
+you know what to look for, at least somewhat, or if you’re provisioning
+one VM at a time.
+
+When the installation process completes, a number of new VMs will be
+available on your machine, all prefixed with ``sd-``.
+
+Editing the configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When developing on the Workstation, make sure to edit files in
+``sd-dev``, then copy them to dom0 via ``make clone && make dev`` to
+reinstall them. Any changes that you make to the
+~/securedrop-workstation folder in dom0 will be overwritten during
+``make clone``. Similarly, any changes you make to e.g. ``/srv/salt/``
+in dom0 will be overwritten by ``make dev``.
+
+Staging Environment
+-------------------
+
+Update ``dom0``, ``fedora-36``, ``whonix-gw-16`` and ``whonix-ws-16`` templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Updates to these VMs will be performed by the installer and updater, but
+updating them prior to install makes it easier to debug any errors.
+
+Before proceeding to updates, we must ensure that ``sys-whonix`` can
+bootstrap to the Tor network. In the Qubes menu, navigate to
+``sys-whonix`` and click on ``Anon Connection Wizard`` and click
+``Next`` and ensure the Tor Bootstrap process completes successfully.
+
+In the Qubes Menu, navigate to ``System Tools`` and click on
+``Qubes Update``. Click the
+``Enable updates for qubes without known available updates`` and select
+all VMs in the list. Click on ``Next`` and wait for updates to complete.
+
+Choose your installation method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can install the staging environment in two ways:
+
+-  If you have an up-to-date clone of this repo with a valid
+   configuration in ``dom0``, you can use the ``make staging`` target to
+   provision a staging environment. Prior to provisioning,
+   ``make staging`` will set your ``config.json`` environment to
+   ``staging``.
+
+-  If you want to download a specific version of the RPM, and follow a
+   verification procedure similar to that used in a production install,
+   follow the process in the following sections.
+
+Download and install securedrop-workstation-dom0-config package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since ``dom0`` does not have network access, we will need to download
+the ``securedrop-workstation-dom0-config`` package in a Fedora-based VM.
+We can use the default Qubes-provisioned ``work`` VM. If you perform
+these changes in the ``work`` VM or another AppVM, they won’t persist
+across reboots (recommended).
+
+In a terminal in ``work``, run the following commands:
+
+1. Import the test signing key:
+
+::
+
+   [user@work ~]$ wget https://raw.githubusercontent.com/freedomofpress/securedrop-workstation/master/sd-workstation/apt-test-pubkey.asc
+   [user@work ~]$ sudo rpmkeys --import apt-test-pubkey.asc
+
+2. Configure the test repository
+
+Populate ``/etc/yum.repos.d/securedrop-temp.repo`` with the following
+contents:
+
+::
+
+   [securedrop-workstation-temporary]
+   enabled=1
+   baseurl=https://yum-test.securedrop.org/workstation/dom0/f32
+   name=SecureDrop Workstation Qubes initial install bootstrap
+
+3. Download the RPM package
+
+::
+
+   [user@work ~]$ dnf download securedrop-workstation-dom0-config
+
+The RPM file will be downloaded to your current working directory.
+
+4. Verify RPM package signature
+
+::
+
+   [user@work ~]$ rpm -Kv securedrop-workstation-dom0-config-x.y.z-1.fc32.noarch.rpm
+
+The output should match the following, and return ``OK`` for all lines
+as follows:
+
+::
+
+   securedrop-workstation-dom0-config-x.y.z-1.fc32.noarch.rpm:
+       Header V4 RSA/SHA256 Signature, key ID 2211b03c: OK
+       Header SHA1 digest: OK
+       V4 RSA/SHA256 Signature, key ID 2211b03c: OK
+       MD5 digest: OK
+
+5. Transfer and install RPM package in ``dom0``
+
+*Understand that*\ `copying data to
+dom0 <https://www.qubes-os.org/doc/copy-from-dom0/#copying-to-dom0>`__\ *goes
+against the grain of the Qubes security philosophy, and should only done
+with trusted code and for very specific purposes. Still, be aware of the
+risks, especially if you rely on your Qubes installation for other
+sensitive work.*
+
+In ``dom0``, run the following commands (changing the version number to
+its current value):
+
+::
+
+   [dom0]$ qvm-run --pass-io work 'cat /home/user/securedrop-workstation-dom0-config-x.y.z-1.fc32.noarch.rpm' > securedrop-workstation.rpm
+   sudo dnf install securedrop-workstation.rpm
+
+The provisioning scripts and tools should now be in place, and you can
+proceed to the workstation configuration step.
+
+Configure the Workstation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Your workstation configuration will reside in
+``/usr/share/securedrop-workstation-dom0-config/`` and will contain
+configuration information specific to your SecureDrop instance:
+
+1. Populate ``config.json`` with your instance-specific variables. Set
+   ``environment`` to ``staging``
+2. Move your submission private key to ``sd-journalist.sec``
+
+.. _provision-the-vms-1:
+
+Provision the VMs
+~~~~~~~~~~~~~~~~~
+
+In a terminal in ``dom0``, run the following commands:
+
+::
+
+   [dom0]$ sdw-admin --apply

--- a/docs/includes/dom0-warning.txt
+++ b/docs/includes/dom0-warning.txt
@@ -1,0 +1,7 @@
+.. note::
+
+    Understand that `copying data to dom0 <https://www.qubes-os.org/doc/copy-from-dom0/#copying-to-dom0>`__ goes
+    against the grain of the Qubes security philosophy, and should only done
+    with trusted code and for very specific purposes, such as Qubes-related
+    development tasks. Still, be aware of the risks, especially if you rely
+    on your Qubes installation for other sensitive work.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,4 +50,7 @@ administrators <https://docs.securedrop.org/>`_.
    :name: sd-workstation
    :maxdepth: 2
 
+   development/workstation_setup
+   development/workstation_development
+   development/workstation_release_management
    development/client


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

Incorporates SecureDrop Workstation developer docs from https://github.com/freedomofpress/securedrop-workstation/ (I've deliberately excluded the data flow diagram and threat model, which might be included with the general documentation).

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] You have previewed (`make docs`) docs at http://localhost:8000
