### PR TITLE
Add kernel testing steps, update release docs

### DIFF
--- a/docs/apt_repo.rst
+++ b/docs/apt_repo.rst
@@ -27,9 +27,9 @@ securedrop-ossec-agent
 securedrop-ossec-server
     Installs the SecureDrop-specific OSSEC configuration for the *Monitor Server*.
 
-`securedrop-grsec <https://github.com/freedomofpress/ansible-role-grsecurity>`_
+securedrop-grsec
     SecureDrop grsecurity kernel metapackage, depending on the latest version
-    of ``linux-image-3.14-*-grsec``.
+    of ``linux-image-*-grsec``.
 
 securedrop-keyring
     Packages the public signing key for this apt repository.

--- a/docs/documentation_guidelines.rst
+++ b/docs/documentation_guidelines.rst
@@ -149,11 +149,9 @@ for a release:
 4. If this is a major-level or minor-level release, make sure to include the
    reminders in ``docs/includes/backup-and-update-reminders.txt`` towards the
    end of the document.
-5. If this release includes a kernel update, make sure to include a reference
-   to the `Kernel Troubleshooting Guide <https://docs.securedrop.org/en/stable/kernel_troubleshooting.html>`_.
-6. If you are not also the release manager, check with them about any other
+5. If you are not also the release manager, check with them about any other
    pertinent release-specific instructions that should be included.
-7. Finally, ensure that mentions of the current version are up to date. You can use
+6. Finally, ensure that mentions of the current version are up to date. You can use
    the ``update_version.sh`` convenience script to do so.
 
    **Example:** If you are adding a guide to upgrade to 2.4.2, you can run

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ administrators <https://docs.securedrop.org/>`_.
    portable_demo
    release_management
    dockerbuildmaint
+   kernel
    updating_tor
 
 .. toctree::

--- a/docs/kernel.rst
+++ b/docs/kernel.rst
@@ -1,0 +1,25 @@
+Linux kernel maintenance
+========================
+
+We build and publish our own Linux kernels with additional
+`grsecurity hardening patches`_.
+The `kernel-builder`_ repository contains scripts that fetch upstream
+kernel tarballs plus grsecurity patches and produces Debian packages.
+
+Testing a new kernel
+--------------------
+
+The following steps should be performed for all of the `recommended hardware`_:
+
+#. Install the new kernel packages on your *Monitor Server*, then reboot. Verify with ``uname -r`` that you are using the new kernel.
+#. If it doesn't boot, see the `Troubleshooting Kernel Updates`_ documentation.
+#. Verify ``paxtest`` doesn't return any errors nor warnings.
+#. Verify the `spectre-meltdown-checker`_ doesn't return any errors nor warnings.
+#. Upgrade your *Application Server* to the new kernel and reboot.
+#. Run basic smoke tests of SecureDrop by verifying you can send a submission and a journalist can reply.
+
+.. _`grsecurity hardening patches`: https://grsecurity.net/`
+.. _`kernel-builder`: https://github.com/freedomofpress/kernel-builder/
+.. _`recommended hardware`: https://docs.securedrop.org/en/stable/hardware.html#application-and-monitor-servers
+.. _`Troubleshooting Kernel Updates`: https://docs.securedrop.org/en/stable/kernel_troubleshooting.html
+.. _`spectre-meltdown-checker`: https://github.com/speed47/spectre-meltdown-checker/

--- a/docs/release_management.rst
+++ b/docs/release_management.rst
@@ -127,10 +127,6 @@ Pre-Release
                   ``ossec-agent-3.6.0-amd64.deb`` in ``main``, do not commit a new version of this
                   deb.
 
-     .. note:: If the release contains other packages not created by ``make build-debs``, such as
-               Tor or kernel updates, make sure that they also get pushed to
-               ``apt-test.freedom.press``.
-
 #. Write a test plan that focuses on the new functionality introduced in the release. Post for
    feedback and make changes based on suggestions from the community. Once it's ready, publish the
    test plan in the `wiki <https://github.com/freedomofpress/securedrop/wiki>`_ and link to it in
@@ -246,11 +242,6 @@ Release Process
    repository, create a branch from ``main`` called ``release``.
 #. In your local branch, commit the built packages to the ``core/focal``
    directory.
-
-   * If the release includes a kernel update, make sure to add the
-     corresponding grsecurity-patched kernel packages, including both
-     ``linux-image-*`` and ``linux-firmware-image-*`` packages as
-     appropriate.
 #. Run the ``tools/publish`` script. This will create the ``Release`` file.
 #. Commit the changes made by the ``tools/publish`` script.
 #. Push your commits to the remote ``release`` branch. This will trigger an


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

* Description:
  * Add Linux kernel testing steps
  * Remove kernel mentions from the release process

* Related Issues
  * https://github.com/freedomofpress/securedrop/issues/6514
  * https://github.com/freedomofpress/securedrop/issues/6328


## Testing
* Visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* No special considerations


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
