### PR TITLE
Fix broken links to appease the linkchecker

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -424,7 +424,7 @@ When features for a new SecureDrop release are frozen, the localization manager 
     release.  If you have suggestions for source strings, please get them to us
     by 2022-03-20.  Translation will end on 2022-03-27.
 
-    Translations are done using Weblate (https://weblate.securedrop.org/projects/securedrop/securedrop/).  If you haven't used it before, <https://docs.securedrop.org/en/stable/development/translations.html> has instructions on how to get started.
+    Translations are done using Weblate (https://weblate.securedrop.org/projects/securedrop/securedrop/).  If you haven't used it before, <https://developers.securedrop.org/en/latest/translations.html> has instructions on how to get started.
 
 * Update Localization Lab via the
   `SecureDrop Coordination <https://community.internetfreedomfestival.org/community/channels/securedrop-coordination>`__ channel

--- a/docs/workstation_release_management.rst
+++ b/docs/workstation_release_management.rst
@@ -36,11 +36,9 @@ In addition, we have the following (Debian) metapackages, which are
 stored in the
 `securedrop-debian-packaging <https://github.com/freedomofpress/securedrop-debian-packaging>`__
 repository: \*
-```securedrop-workstation-config`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/master/securedrop-workstation-config/debian>`__
+```securedrop-workstation-config`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/securedrop-workstation-config/debian>`__
 \*
-```securedrop-workstation-grsec`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/master/securedrop-workstation-grsec>`__
-\*
-```securedrop-workstation-viewer`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/master/securedrop-workstation-viewer>`__
+```securedrop-workstation-viewer`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/securedrop-workstation-viewer>`__
 
 The release process for a metapackage is generally to bump the version,
 update the debian changelog, and then tag

--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -77,7 +77,7 @@ environment configuration.
 
 Decide on a VM to use for development. We recommend creating a
 standalone VM called ``sd-dev`` by following `these
-instructions <https://docs.securedrop.org/en/stable/development/setup_development.html#qubes>`__.
+instructions <https://developers.securedrop.org/en/latest/setup_development.html#qubes>`__.
 
 Clone this repo to your preferred location on that VM.
 


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

* Description: Fixes a couple broken URLs, and also removes the `securedrop-workstation-grsec` link since that was intentionally removed (and now is a permanent 404)

* Resolves #20 

## Testing
* Clone branch and run `make docs-linkcheck`


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
