### PR TITLE
Fix stray ` in kernel.rst

### DIFF
--- a/docs/kernel.rst
+++ b/docs/kernel.rst
@@ -18,7 +18,7 @@ The following steps should be performed for all of the `recommended hardware`_:
 #. Upgrade your *Application Server* to the new kernel and reboot.
 #. Run basic smoke tests of SecureDrop by verifying you can send a submission and a journalist can reply.
 
-.. _`grsecurity hardening patches`: https://grsecurity.net/`
+.. _`grsecurity hardening patches`: https://grsecurity.net/
 .. _`kernel-builder`: https://github.com/freedomofpress/kernel-builder/
 .. _`recommended hardware`: https://docs.securedrop.org/en/stable/hardware.html#application-and-monitor-servers
 .. _`Troubleshooting Kernel Updates`: https://docs.securedrop.org/en/stable/kernel_troubleshooting.html


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Description: 
Accidentally got added to the end of a URL, which managed to entirely wreck the PDF generation by causing pdflatex to overflow its stack limit.

See <https://github.com/freedomofpress/securedrop-dev-docs/pull/5#issuecomment-1268989517>.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] First comment out the `git checkout $1` line in `deploy/build` so it doesn't switch branches on you.
* [ ] Then run `podman build -f deploy/Dockerfile -t dev-docs .` (or docker)

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* no


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
