### PR TITLE
Fix link formatting

### DIFF
--- a/docs/workstation_release_management.rst
+++ b/docs/workstation_release_management.rst
@@ -33,12 +33,11 @@ official release key. Later releases, as the subprojects were prepared
 for production, had their tags signed with the official release key.
 
 In addition, we have the following (Debian) metapackages, which are
-stored in the
-`securedrop-debian-packaging <https://github.com/freedomofpress/securedrop-debian-packaging>`__
-repository: \*
-```securedrop-workstation-config`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/securedrop-workstation-config/debian>`__
-\*
-```securedrop-workstation-viewer`` <https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/securedrop-workstation-viewer>`__
+stored in the `securedrop-debian-packaging <https://github.com/freedomofpress/securedrop-debian-packaging>`__
+repository:
+
+- `securedrop-workstation-config <https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/securedrop-workstation-config>`__
+- `securedrop-workstation-viewer <https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/securedrop-workstation-viewer>`__
 
 The release process for a metapackage is generally to bump the version,
 update the debian changelog, and then tag


### PR DESCRIPTION
## Status
Ready for review 
## Description of Changes

Fixes formatting syntax that got messed up during the import

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
