### PR TITLE
Test build step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,23 @@ jobs:
             source .venv/bin/activate
             make docs-linkcheck
 
+  build:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build production deployment
+          command: |
+            apt-get update && apt-get install docker.io -y
+            docker build --build-arg GIT_BRANCH=${CIRCLE_BRANCH} -f deploy/Dockerfile .
+
 workflows:
   version: 2
   build:
     jobs:
+      - build
       - lint
 
   nightly:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,10 +1,11 @@
 # sha256 as of 2022-09-13
 FROM python:3.9-slim-bullseye@sha256:09c9438d7b13587df2b1b798d372442fb2bdda6cd408aa89dda2e995868c0b31 AS sphinx
 
+ARG GIT_BRANCH=main
 RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra
 COPY ./ .
 RUN pip install -r requirements/requirements.txt
-RUN deploy/build
+RUN deploy/build $GIT_BRANCH
 
 # sha256 as of 2022-09-13
 FROM nginx:mainline-alpine@sha256:2959a35e1b1e61e2419c01e0e457f75497e02d039360a658b66ff2d4caab19c4

--- a/deploy/build
+++ b/deploy/build
@@ -5,9 +5,6 @@
 
 set -e
 
-
-latest_branch=main
-
 do_build() {
     git checkout "$1"
 
@@ -20,4 +17,4 @@ do_build() {
 }
 
 export SECUREDROP_DOCS_RELEASE=latest
-do_build "$latest_branch" latest
+do_build "$1" latest


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

Recently #5 caused breakage of the automated deployment because of a syntax typo (fixed in #23). It broke the building of the PDF, which is not otherwise tested and slow for developers to build it locally constantly.

CI now has a build job that will build the deployment docker image just as it does in the real deployment step. Instead of forcing it to always build "main", allow a different branch to be tested with `--build-arg GIT_BRANCH=...`.

## Testing
* [ ] CI passes

## Release 
* no considerations


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
