### PR TITLE
Improve kernel testing instructions

### DIFF
--- a/docs/kernel.rst
+++ b/docs/kernel.rst
@@ -13,8 +13,10 @@ The following steps should be performed for all of the `recommended hardware`_:
 
 #. Install the new kernel packages on your *Monitor Server*, then reboot. Verify with ``uname -r`` that you are using the new kernel.
 #. If it doesn't boot, see the `Troubleshooting Kernel Updates`_ documentation.
-#. Verify ``paxtest`` doesn't return any errors nor warnings.
-#. Verify the `spectre-meltdown-checker`_ doesn't return any errors nor warnings.
+#. Install the ``paxtest`` package, run with ``sudo paxtest blackhat``, and verify it doesn't
+   return any new errors nor warnings.
+#. Install `spectre-meltdown-checker`_ and the ``binutils`` package, run with
+   ``sudo ./meltdown-checker``, and verify it doesn't return any errors nor warnings.
 #. Upgrade your *Application Server* to the new kernel and reboot.
 #. Run basic smoke tests of SecureDrop by verifying you can send a submission and a journalist can reply.
 


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

* Probably need to install paxtest, must be run as root. Some things will be marked as vulnerable, but we mostly want to catch regressions.
* Install `binutils` for the spectre-meltdown-checker, and also run it as root.


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* Visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* no


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
