### PR TITLE
publish policy on supported languages

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -103,15 +103,11 @@ Development tasks
 Add a new language
 ^^^^^^^^^^^^^^^^^^
 
-Any Weblate contributor may visit the `Weblate translation creation page`_ and
-the `Weblate desktop translation creation page`_ to add a new language.
+See :ref:`how_to_add_a_new_language`.
 
 However, SecureDrop only supports a subset of all the languages being worked on
-in `Weblate`_: some of them are partially translated or not fully reviewed. The
-list of fully supported languages is hard-coded in the `i18n.json`_ file, in
-the ``supported_locales`` object. When a new language is completely translated
-and reviewed, ``i18n.json`` must be manually edited to add this new language to
-the ``supported_locales`` variable.
+in `Weblate`_.   New languages are supported according to the
+:doc:`supported_languages`.
 
 .. _update_strings_to_be_translated:
 

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -453,6 +453,8 @@ current set of supported languages at 100% translation in Weblate.
 Localization Lab can marshal individual translators to help meet this
 goal.
 
+.. _release_day:
+
 Release day
 ^^^^^^^^^^^
 .. note::

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -78,8 +78,8 @@ What languages are available where?
 
 * All languages *translated* in Weblate are *present* in the
   ``securedrop/translations`` directory.
-* *Supported* languages are listed in the ``supported_locales`` object in the
-  `i18n.json`_ file.
+* :doc:`Supported languages <supported_languages>` are listed in the
+  ``supported_locales`` object in the `i18n.json`_ file.
 * Those languages that are both *present* and *supported* are *available* for
   administrators to *configure* in ``securedrop-admin sdconfig``.
 * Those languages that are both *configured* and *available* on the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ administrators <https://docs.securedrop.org/>`_.
    translations
    contributor_guidelines
    tips_and_tricks
+   supported_languages
 
 .. toctree::
    :caption: SecureDrop Server

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -10,6 +10,11 @@ Policy on Supported Languages
    * - `4 <https://github.com/freedomofpress/securedrop-engineering/issues/6>`_
      - 7 February 2023
 
+.. note::
+   The key words *MUST*, *MUST NOT*, *REQUIRED*, *SHALL*, *SHALL NOT*, *SHOULD*,
+   *SHOULD NOT*, *RECOMMENDED*,  *MAY*, and *OPTIONAL* in this document are to be
+   interpreted as described in `RFC 2119`_.
+
 Thresholds for Translation and Review Coverage
 ----------------------------------------------
 
@@ -70,4 +75,5 @@ such as communication, are left to the discretion of the Localization Manager.
 .. [#source_components] As of this writing, to include any future source-facing
    components.
 
+.. _`RFC 2119`: https://datatracker.ietf.org/doc/html/rfc2119
 .. _`language team`: https://wiki.localizationlab.org/index.php/Category:Language_Teams

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -10,10 +10,23 @@ Policy on Supported Languages
    * - `5 <https://github.com/freedomofpress/securedrop-engineering/issues/6>`_
      - 8 March 2023
 
+
+Definitions
+-----------
+
 .. note::
    The key words *MUST*, *MUST NOT*, *REQUIRED*, *SHALL*, *SHALL NOT*, *SHOULD*,
    *SHOULD NOT*, *RECOMMENDED*,  *MAY*, and *OPTIONAL* in this document are to be
    interpreted as described in `RFC 2119`_.
+
+.. glossary::
+
+   translation freeze
+
+      The deadline for translations to be reviewed and merged in order to be
+      included in a given release.  For SecureDrop, this is :ref:`release day
+      <release_day>`.
+
 
 Thresholds for Translation and Review Coverage
 ----------------------------------------------
@@ -50,7 +63,8 @@ Granting support for a new language consists of adding an entry in the
 such as communication, are at the discretion of the Localization Manager.
 
 #. A language *L* that reaches coverage in time for a release
-   version *V* SHOULD be nominated for support in version *V*.
+   version *V*'s :term:`translation freeze` SHOULD be nominated for support in
+   version *V*.
 
 #. The Localization Manager SHOULD ask Localization Lab whether they
    believe *L*'s `language team`_ is likely to be able to maintain coverage for
@@ -75,7 +89,7 @@ Consider an expected release timeline as follows:
    :stub-columns: 1
 
    * - Version
-     - Date
+     - :term:`Translation Freeze`
    * - V1
      - January 1
    * - V2
@@ -85,19 +99,20 @@ Consider an expected release timeline as follows:
 
 Then:
 
-#. A language *L* that misses coverage for a release version *V1* MUST be
-   considered on probation for up to the next two releases *V2* and *V3*.
-   While on probation, a language is still considered supported until it has
-   missed coverage for a total of 3 consecutive release/localization cycles.
+#. A language *L* that misses coverage for a release version *V1*'s
+   :term:`translation freeze` MUST be considered on probation for up to the next
+   two releases *V2* and *V3*.  While on probation, a language is still
+   considered supported until it has missed coverage for a total of 3
+   consecutive translation freezes.
 
         #. In consultation with Localization Lab, the Localization
            Manager MAY consult the `language census`_ and reach out to
            administrators who may be able to contribute to translation and
            review.
 
-#. If *L* misses coverage again for *V2* and does not regain
-   coverage for *V3*, then the Localization Manager SHOULD revoke support for
-   *L* for *V3*.
+#. If *L* misses coverage again for *V2*'s translation freeze and does not
+   regain coverage for *V3*'s translation freeze, then the Localization Manager
+   SHOULD revoke support for *L* for *V3*.
 
         #. In consultation with Localization Lab and the Release
            Manager, the Localization Manager MAY extend *L*’s probationary

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -1,2 +1,45 @@
 Policy on Supported Languages
 =============================
+
+*Revision 4, approved 7 February 2023*
+
+Thresholds for Translation and Review Coverage
+----------------------------------------------
+
+.. list-table::
+   :widths: 30 30 30
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Component
+     - Translation Coverage (of Source Strings)
+     - Review Coverage (of Translations) [#review_coverage]_
+   * - Source Interface [#source_components]_
+     - 100%
+     - 100%
+   * - Journalist Interface; SecureDrop Client [#journalist_components]_
+     - 80%
+     - 100%
+
+The goals of these thresholds are to:
+
+#. emphasize to **translators and reviewers** the importance of
+   translating and reviewing source-facing strings;
+
+#. emphasize to **code contributors and maintainers** the higher
+   cost and risk involved in changing source (English) strings in source-facing
+   components compared to others; and
+
+#. maximize the correctness of the translations we ultimately ship.
+
+.. rubric:: Footnotes
+
+.. [#journalist_components] As of this writing, to include any future
+   journalist-, admin, or otherwise *non*-source-facing components.
+
+.. [#review_coverage] Machine translation (e.g., Google Translate) MAY be used
+   to close gaps in review coverage for an otherwise well-supported language.
+   (It MAY NOT be used to close gaps in translation coverage.)
+
+.. [#source_components] As of this writing, to include any future source-facing
+   components.

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -21,14 +21,15 @@ Thresholds for Translation and Review Coverage
 .. list-table::
    :widths: 30 30 30
    :header-rows: 1
+   :stub-columns: 1
 
    * -
-     - Translation Coverage (of Source Strings)
-     - Review Coverage (of Translations) [#review_coverage]_
-   * - **Initial coverage,** for a language to be granted support
+     - Translation Coverage
+     - Review Coverage [#review_coverage]_
+   * - To grant support
      - 100%
      - 100%
-   * - **Ongoing coverage,** for a language to remain supported
+   * - To maintain support
      - 80%
      - 100%
 

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -1,0 +1,2 @@
+Policy on Supported Languages
+=============================

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -1,7 +1,14 @@
 Policy on Supported Languages
 =============================
 
-*Revision 4, approved 7 February 2023*
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Version
+     - Approved
+   * - `4 <https://github.com/freedomofpress/securedrop-engineering/issues/6>`_
+     - 7 February 2023
 
 Thresholds for Translation and Review Coverage
 ----------------------------------------------

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -48,9 +48,9 @@ Granting Support for a Language
 -------------------------------
 
 Granting support for a new language consists of adding an entry in the
-``supported_locales`` object in ``securedrop``'s ``i18n.json`` and in the
+``supported_locales`` object in ``securedrop``'s ``i18n.json`` and/or in the
 "Localization" section in ``securedrop-client``'s ``MANIFEST.in``.  Other steps,
-such as communication, are left to the discretion of the Localization Manager.
+such as communication, are at the discretion of the Localization Manager.
 
 #. A language *L* that reaches coverage in time for a release
    version *V* SHOULD be nominated for support in version *V*.
@@ -63,6 +63,50 @@ such as communication, are left to the discretion of the Localization Manager.
 
         #. If not, the Localization Manager MUST NOT grant support for *L*.
 
+Revoking Support for a Language
+-------------------------------
+
+Revoking support for a currently-supported language consists of removing the
+language's entries in ``i18n.json`` and/or ``MANIFEST.in``.  Other steps, such
+as communication, are at the discretion of the Localization Manager.
+
+Consider an expected release timeline as follows:
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Version
+     - Date
+   * - V1
+     - January 1
+   * - V2
+     - March 1
+   * - V3
+     - May 1
+
+Then:
+
+#. A language *L* that misses coverage for a release version *V1*
+   MUST be considered on probation.
+
+        #. In consultation with Localization Lab, the Localization
+           Manager MAY consult the `language census`_ and reach out to
+           administrators who may be able to contribute to translation and
+           review.
+
+#. If *L* misses coverage again for *V2* and does not regain
+   coverage for *V3*, then the Localization Manager SHOULD revoke support for
+   *L* for *V3*.
+
+        #. In consultation with Localization Lab and the Release
+           Manager, the Localization Manager MAY extend *L*’s probationary
+           period, for example if the `language census`_ indicates that revoking
+           support for *L* would jeopardize the default locale for many
+           instances, for especially high-traffic or high-profile instances,
+           etc.
+           
 .. rubric:: Footnotes
 
 .. [#journalist_components] As of this writing, to include any future
@@ -76,4 +120,5 @@ such as communication, are left to the discretion of the Localization Manager.
    components.
 
 .. _`RFC 2119`: https://datatracker.ietf.org/doc/html/rfc2119
+.. _`language census`: https://github.com/freedomofpress/i18n_scan
 .. _`language team`: https://wiki.localizationlab.org/index.php/Category:Language_Teams

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -7,8 +7,8 @@ Policy on Supported Languages
 
    * - Version
      - Approved
-   * - `4 <https://github.com/freedomofpress/securedrop-engineering/issues/6>`_
-     - 7 February 2023
+   * - `5 <https://github.com/freedomofpress/securedrop-engineering/issues/6>`_
+     - 8 March 2023
 
 .. note::
    The key words *MUST*, *MUST NOT*, *REQUIRED*, *SHALL*, *SHALL NOT*, *SHOULD*,
@@ -21,28 +21,24 @@ Thresholds for Translation and Review Coverage
 .. list-table::
    :widths: 30 30 30
    :header-rows: 1
-   :stub-columns: 1
 
-   * - Component
+   * -
      - Translation Coverage (of Source Strings)
      - Review Coverage (of Translations) [#review_coverage]_
-   * - Source Interface [#source_components]_
+   * - **Initial coverage,** for a language to be granted support
      - 100%
      - 100%
-   * - Journalist Interface; SecureDrop Client [#journalist_components]_
+   * - **Ongoing coverage,** for a language to remain supported
      - 80%
      - 100%
 
-The goals of these thresholds are to:
+In addition to these thresholds, the SecureDrop team will:
 
-#. emphasize to **translators and reviewers** the importance of
-   translating and reviewing source-facing strings;
+#. always prioritize the translation of source-facing strings, given their
+   importance for sources' security; and
 
-#. emphasize to **code contributors and maintainers** the higher
-   cost and risk involved in changing source (English) strings in source-facing
-   components compared to others; and
-
-#. maximize the correctness of the translations we ultimately ship.
+#. inform Localization Lab when particular strings should be prioritized or
+   even considered blocking for a given release.
 
 Granting Support for a Language
 -------------------------------
@@ -88,8 +84,10 @@ Consider an expected release timeline as follows:
 
 Then:
 
-#. A language *L* that misses coverage for a release version *V1*
-   MUST be considered on probation.
+#. A language *L* that misses coverage for a release version *V1* MUST be
+   considered on probation for up to the next two releases *V2* and *V3*.
+   While on probation, a language is still considered supported until it has
+   missed coverage for a total of 3 consecutive release/localization cycles.
 
         #. In consultation with Localization Lab, the Localization
            Manager MAY consult the `language census`_ and reach out to
@@ -115,15 +113,12 @@ Weblate.
 
 .. rubric:: Footnotes
 
-.. [#journalist_components] As of this writing, to include any future
-   journalist-, admin, or otherwise *non*-source-facing components.
-
 .. [#review_coverage] Machine translation (e.g., Google Translate) MAY be used
    to close gaps in review coverage for an otherwise well-supported language.
-   (It MAY NOT be used to close gaps in translation coverage.)
-
-.. [#source_components] As of this writing, to include any future source-facing
-   components.
+   (It MAY NOT be used to close gaps in translation coverage.)  Because of the
+   risk of low-quality machine translations especially from minority languages,
+   machine translation SHOULD be considered a last resort, on a case-by-case
+   basis in consultation with Localization Lab.
 
 .. _`RFC 2119`: https://datatracker.ietf.org/doc/html/rfc2119
 .. _`language census`: https://github.com/freedomofpress/i18n_scan

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -107,6 +107,12 @@ Then:
            instances, for especially high-traffic or high-profile instances,
            etc.
            
+Adding a New Language for Translation
+-------------------------------------
+
+Translators MUST ask Localization Lab to add a new language for translation in
+Weblate.
+
 .. rubric:: Footnotes
 
 .. [#journalist_components] As of this writing, to include any future

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -32,6 +32,25 @@ The goals of these thresholds are to:
 
 #. maximize the correctness of the translations we ultimately ship.
 
+Granting Support for a Language
+-------------------------------
+
+Granting support for a new language consists of adding an entry in the
+``supported_locales`` object in ``securedrop``'s ``i18n.json`` and in the
+"Localization" section in ``securedrop-client``'s ``MANIFEST.in``.  Other steps,
+such as communication, are left to the discretion of the Localization Manager.
+
+#. A language *L* that reaches coverage in time for a release
+   version *V* SHOULD be nominated for support in version *V*.
+
+#. The Localization Manager SHOULD ask Localization Lab whether they
+   believe *L*'s `language team`_ is likely to be able to maintain coverage for
+   the foreseeable future.
+
+        #. If so, the Localization Manager SHOULD grant support for *L*.
+
+        #. If not, the Localization Manager MUST NOT grant support for *L*.
+
 .. rubric:: Footnotes
 
 .. [#journalist_components] As of this writing, to include any future
@@ -43,3 +62,5 @@ The goals of these thresholds are to:
 
 .. [#source_components] As of this writing, to include any future source-facing
    components.
+
+.. _`language team`: https://wiki.localizationlab.org/index.php/Category:Language_Teams

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -418,16 +418,20 @@ In order to review the demo server as a *journalist*:
 How to become a reviewer
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can ask to become a reviewer for a language by posting a message
-in the `translations category of the SecureDrop forum`_.
+`Contact Localization Lab`_ to ask to join a `language team`_ as a reviewer.
 
 .. _how_to_add_a_new_language:
 
 How to add a new language to SecureDrop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We love seeing SecureDrop translated into new languages. Just ask us
-to add yours by posting in the `translations category of the SecureDrop forum`_.
+We love seeing SecureDrop translated into new languages.  `Contact Localization
+Lab`_ to ask to join a `language team`_ (or start a new one) and have the new
+language added to Weblate.
+
+However, SecureDrop only supports a subset of all the languages being worked on
+in `Weblate`_.   New languages are supported according to the
+:doc:`supported_languages`.
 
 .. _weblate_glossary:
 
@@ -485,3 +489,5 @@ Source strings are English phrases and are automatically extracted from SecureDr
 .. _`SecureDrop Workstation`: https://workstation.securedrop.org
 .. _`SecureDrop Workstation documentation`: https://workstation.securedrop.org
 .. _`Localization Lab`: https://www.localizationlab.org/
+.. _`Contact Localization Lab`: https://wiki.localizationlab.org/index.php/Communication_Platforms
+.. _`language team`: https://wiki.localizationlab.org/index.php/Category:Language_Teams


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards freedomofpress/securedrop#6592:
- converts to ReST the "Policy on Supported Languages" approved in freedomofpress/securedrop-engineering#6 and subsequently revised based on feedback from Localization Lab; and
- steers new reviewers and new-language requests to Localization Lab.


## Testing
- [ ] `supported_languages.rst` looks good based on freedomofpress/engineering#6.
- [ ] Other changes look good and are consistent with the rest of our documentation.

## Release 

*None* 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
