### PR TITLE
Fix broken links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,4 +323,5 @@ linkcheck_ignore = [
     r"https://docs.securedrop.org/?$",
     r"https://support-docs.securedrop.org/?$",
     "https://support.yubico.com/hc/en-us/articles/360016614780-OATH-HOTP-Yubico-Best-Practices-Guide",
+    r"https://github.com/freedomofpress/securedrop-builder/.*"
 ]

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -446,7 +446,7 @@ When features for a new SecureDrop release are frozen, the localization manager 
 
 * Update Localization Lab via the
   `SecureDrop Coordination <https://community.internetfreedomfestival.org/community/channels/securedrop-coordination>`__ channel
-  in the `IFF Mattermost <https://internetfreedomfestival.org/wiki/index.php/IFF_Mattermost>`__.
+  in the `TCU Mattermost <https://wiki.digitalrights.community/index.php?title=TCU_Mattermost>`__.
 * During the feedback period, monitor Weblate comments and suggestions, and open
   a pull request for every source string suggestion coming from translators.
 

--- a/docs/includes/dom0-warning.txt
+++ b/docs/includes/dom0-warning.txt
@@ -1,6 +1,6 @@
 .. note::
 
-    Understand that `copying data to dom0 <https://www.qubes-os.org/doc/copy-from-dom0/#copying-to-dom0>`__ goes
+    Understand that `copying data to dom0 <https://www.qubes-os.org/doc/how-to-copy-from-dom0/#copying-to-dom0>`__ goes
     against the grain of the Qubes security philosophy, and should only done
     with trusted code and for very specific purposes, such as Qubes-related
     development tasks. Still, be aware of the risks, especially if you rely

--- a/docs/virtualizing_tails.rst
+++ b/docs/virtualizing_tails.rst
@@ -25,7 +25,7 @@ Create a VM using virt-manager
 
 Follow the Tails virt-manager instructions for
 `running Tails from a USB image <https://tails.boum.org/doc/advanced_topics/virtualization/virt-manager/index.en.html#index4h1>`__.
-Then proceed with booting to the USB drive, and `configure Persistent Storage <https://tails.boum.org/doc/first_steps/persistence/index.en.html>`__.
+Then proceed with booting to the USB drive, and `configure Persistent Storage <https://tails.boum.org/doc/persistent_storage/index.en.html>`__.
 
 We recommend cloning the SecureDrop repository into the persistent volume for
 testing and development, instead of attempting to mount a folder from the host


### PR DESCRIPTION
GitHub URLs tend to error out for two reasons: rate-limiting, and link fragments (GitHub uses JavaScript to resolve link fragments; the link checker expects to find a named anchor in the page). So we generally add them to the ignore-list. The other cases are more straightforward URL changes.

## Status

Ready for review 