### PR TITLE
Consolidate documention on build logs, document .buildinfo files

### DIFF
--- a/docs/build_metadata.rst
+++ b/docs/build_metadata.rst
@@ -1,0 +1,34 @@
+Build metadata
+==============
+
+When we build packages to ship to users, we save and publish build metadata.
+Currently this happens in the form of build logs and ``.buildinfo`` files, both
+of which are published to the `build-logs <https://github.com/freedomofpress/build-logs>`__ repository.
+
+Build logs
+----------
+
+Builders should save their terminal output starting with:
+
+* Checking out the build tag and verifying that it is signed with the release key
+* ``make build-debs`` (or equivalent) output
+* SHA256 checksums of the built packages
+
+These should be committed into the corresponding folder in the build-logs repository.
+
+The goal with these build logs is to have a clear record of what happened during
+the build process for the purpose of retrospectives. This can help us determine if
+mistakes are made during the build (since some of the process is manual) and for
+incident response.
+
+buildinfo
+---------
+
+``.buildinfo`` files record information about the environment used to build the package
+so that an external user can recreate that environment and reproduce the package. See
+the `Debian documentation <https://wiki.debian.org/ReproducibleBuilds/BuildinfoFiles>`__ for more details.
+
+When available, these should be committed into the ``buildinfo/`` folder. As these files
+also contain SHA256 checksums of the packages, they can be omitted from the build log.
+
+These are not yet `generated for RPM packages <https://github.com/freedomofpress/securedrop-builder/issues/418>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ administrators <https://docs.securedrop.org/>`_.
    apparmor_profiles
    portable_demo
    release_management
+   build_metadata
    dockerbuildmaint
    kernel
    updating_tor

--- a/docs/release_management.rst
+++ b/docs/release_management.rst
@@ -114,8 +114,7 @@ Pre-Release
                update the build container, you can ignore this test failure until you are building a
                production release.
 
-   c. Build logs should be saved and published according to the `build log guidelines
-      <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
+   c. Save and publish :doc:`build metadata <build_metadata>`.
    d. Open a PR on `securedrop-apt-test
       <https://github.com/freedomofpress/securedrop-apt-test>`_ that targets the ``main``
       branch with the new debs. Do not include tarballs or any debs that would overwrite
@@ -234,9 +233,7 @@ Release Process
 
    a. Verify and check out the signed tag for the release.
    #. Build the packages with ``make build-debs``.
-   #. Build logs should be saved and published according to the `build
-      log guidelines
-      <https://github.com/freedomofpress/securedrop/wiki/Build-logs>`_.
+   #. Save and publish :doc:`build metadata <build_metadata>`.
 #. In a clone of the private
    `securedrop-apt-prod <https://github.com/freedomofpress/securedrop-apt-prod>`_
    repository, create a branch from ``main`` called ``release``.

--- a/docs/workstation_release_management.rst
+++ b/docs/workstation_release_management.rst
@@ -61,10 +61,9 @@ Step 2: Build and deploy the package to ``apt-test``
 
   .. code-block:: sh
 
-   sha256sum bulid/debbuild/packaging/securedrop-foobar_x.y.z-rcN.deb
+   sha256sum build/debbuild/packaging/securedrop-foobar_x.y.z-rcN.deb
 
-6. Save and publish your terminal history to the `build-logs <https://github.com/freedomofpress/build-logs>`__ repository in the workstation directory.
-
+6. Save and publish :doc:`build metadata <build_metadata>`.
 7. Open a PR to https://github.com/freedomofpress/securedrop-apt-test with the package you want to deploy. Remember to link to your build logs commit. Once your PR is merged, the package will be deployed to https://apt-test.freedom.press.
 
 Step 3: Begin QA
@@ -107,12 +106,12 @@ In this step, you will build a production version of the package to first be dep
 
   .. code-block:: sh
 
-   sha256sum bulid/debbuild/packaging/securedrop-foobar_x.y.z.deb
+   sha256sum build/debbuild/packaging/securedrop-foobar_x.y.z.deb
 
-5. Save and publish your terminal history to the `build-logs <https://github.com/freedomofpress/build-logs>`__ repository in the workstation directory.
-6. Add your package to a new branch called ``release`` in https://github.com/freedomofpress/securedrop-apt-prod. 
+5. Save and publish :doc:`build metadata <build_metadata>`.
+6. Add your package to a new branch called ``release`` in https://github.com/freedomofpress/securedrop-apt-prod.
 7. Update the apt repo distribution files by running ``./tools/publish`` and push those changes to the ``release`` branch as well. This will deploy your pakcage to https://apt-qa.freedom.press.
-8. Open a PR to merge the ``release`` branch into ``main``. Remember to link to the new ``build-logs`` commit. DO NOT MERGE. First, you will perform the ``apt-qa`` preflight check in the next step.
+8. Open a PR to merge the ``release`` branch into ``main``. DO NOT MERGE. First, you will perform the ``apt-qa`` preflight check in the next step.
 
 Step 6: Perform the ``apt-qa`` preflight check
 ----------------------------------------------
@@ -154,11 +153,7 @@ Release ``securedrop-workstation-dom0-config``
 8.  Sign RPM in place (see Signing section below).
 9.  Move the signed RPM back to the environment for committing to the
     lfs repository.
-10. Upload build logs directly to the
-    `build-logs <https://github.com/freedomofpress/build-logs>`__
-    repository in the workstation directory. Ensure that the sha256sum
-    of the package before and after signing is included in the build
-    log.
+10. Save and publish :doc:`build metadata <build_metadata>`.
 11. Commit the RPM in a second commit on the branch you began above in
     `securedrop-yum-prod <https://github.com/freedomofpress/securedrop-yum-prod>`__.
     Make a PR.
@@ -188,9 +183,7 @@ production (``yum.securedrop.org``) using the following procedure:
 8.  Push those two commits to a PR in
     `securedrop-yum-test <https://github.com/freedomofpress/securedrop-yum-test/>`__.
     Make the PR.
-9.  Upload build logs directly to the
-    `build-logs <https://github.com/freedomofpress/build-logs>`__
-    repository in the workstation directory.
+9.  Save and publish :doc:`build metadata <build_metadata>`.
 10. Upon merge of the PR into
     `securedrop-yum-test <https://github.com/freedomofpress/securedrop-yum-test/>`__,
     the template will be deployed to ``yum-test.securedrop.org``.


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Description: 

Create a new "Build metadata" page that consolidates documentation from <https://github.com/freedomofpress/securedrop/wiki/Build-logs> and parts of the release management guides.

We are also going to start requiring the publishing of `.buildinfo` files (see https://github.com/freedomofpress/securedrop/pull/6754), so document how they work and where they should be published.

* Related Issues
  * https://github.com/freedomofpress/securedrop/pull/6754
  * https://github.com/freedomofpress/securedrop/issues/6356


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* Visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* No


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
