### PR TITLE
Configure dependabot to update dependencies weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

dependabot should submit no more than five pull requests once a week, automatically updating dependencies via pyproject.toml/poetry.lock.

This is somewhat conservative for now as an experiment, we can tweak it if we want faster updates or more of them at once.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* Visual review, cross-reference with https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* No
