### PR TITLE
Add `make` install instruction in dom0, bump Fedora and Debian versions

### DIFF
--- a/docs/qubes_staging.rst
+++ b/docs/qubes_staging.rst
@@ -169,12 +169,12 @@ Inter-VM networking
 
 We want to be able to SSH connections from ``sd-dev`` to these new standalone VMs.
 In order to do so, we have to adjust the firewall rules. Make the following changes on
-``fedora-36-dvm``, which is the template for ``sys-firewall`` under a default setup.
+``fedora-37-dvm``, which is the template for ``sys-firewall`` under a default setup.
 
 .. note::
 
    These changes to the firewall rules will also apply to all other DispVMs based off
-   ``fedora-36-dvm``, and are meant for a testing/development machine only.
+   ``fedora-37-dvm``, and are meant for a testing/development machine only.
 
 Let's get the IP address of ``sd-dev``. On ``dom0``:
 
@@ -182,7 +182,7 @@ Let's get the IP address of ``sd-dev``. On ``dom0``:
 
    qvm-prefs sd-dev ip
 
-Get a shell on ``fedora-36-dvm``. Create or edit
+Get a shell on ``fedora-37-dvm``. Create or edit
 ``/rw/config/qubes-firewall-user-script``, to include the following:
 
 .. code:: sh
@@ -196,7 +196,7 @@ Get a shell on ``fedora-36-dvm``. Create or edit
    iptables -I FORWARD 2 -s "$sd_app" -d "$sd_mon" -j ACCEPT
    iptables -I FORWARD 2 -s "$sd_mon" -d "$sd_app" -j ACCEPT
 
-Shut down ``fedora-36-dvm``, then restart ``sys-firewall``.
+Shut down ``fedora-37-dvm``, then restart ``sys-firewall``.
 
 Now from ``sd-dev``, you should be able to do
 

--- a/docs/setup_development.rst
+++ b/docs/setup_development.rst
@@ -80,13 +80,13 @@ Install Docker_.
 Qubes
 ~~~~~
 
-Create a StandaloneVM based on Debian 10, called ``sd-dev``.
+Create a StandaloneVM based on Debian 11, called ``sd-dev``.
 You can use the **Q** menu to configure a new VM, or run
 the following in ``dom0``:
 
 .. code:: sh
 
-   qvm-clone --class StandaloneVM debian-10 sd-dev
+   qvm-clone --class StandaloneVM debian-11 sd-dev
    qvm-start sd-dev
    qvm-sync-appmenus sd-dev
 

--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -18,16 +18,18 @@ Install Qubes
 -------------
 
 Before trying to use this project, install `Qubes
-4.1.1 <https://www.qubes-os.org/downloads/>`__ on your development
+4.1.2 <https://www.qubes-os.org/downloads/>`__ on your development
 machine. Accept the default VM configuration during the install process.
 
 After installing Qubes, you must update both dom0 and the base templates
-to include the latest versions of apt packages. Open a terminal in
+to include the latest versions of apt packages, as well as install an
+additional dependency (``make``) in dom0. Open a terminal in
 ``dom0`` by clicking on the Qubes menu top-right of the screen and
 left-clicking on Terminal Emulator and run:
 
 ::
 
+   sudo qubes-dom0-update -y make
    sudo qubes-dom0-update
 
 After dom0 updates complete, reboot your computer to ensure the updates
@@ -191,7 +193,7 @@ in dom0 will be overwritten by ``make dev``.
 Staging Environment
 -------------------
 
-Update ``dom0``, ``fedora-36``, ``whonix-gw-16`` and ``whonix-ws-16`` templates
+Update ``dom0``, ``fedora-37``, ``whonix-gw-16`` and ``whonix-ws-16`` templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Updates to these VMs will be performed by the installer and updater, but


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

* To `make dev`, `make clone`, etc (non-prod workstation provisioning) on QubesOS,  `make` must be installed in dom0. Add instructions
* f36->f37, debian 10-> debian 11 where appropriate
