### PR TITLE
Run CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: debian:bullseye
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install --yes --no-install-recommends make python3-pip
+          pip install poetry==1.4.0
+          poetry install --no-ansi
+      - name: Run lint
+        run: |
+          make docs-lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build production deployment
+        run: |
+          docker build --build-arg GIT_BRANCH=$(git rev-parse HEAD) --file deploy/Dockerfile .

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,19 @@
+name: Link check
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    container: debian:bullseye
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install --yes --no-install-recommends make python3-pip
+          pip install poetry==1.4.0
+          poetry install --no-ansi
+      - name: Run lint
+        run: |
+          make docs-linkcheck


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

This is a basically identical port of the existing CircleCI jobs
to GitHub Actions.

The linkcheck job is configured separately since it runs on a cron
rather than on push/PR.

Refs <https://github.com/freedomofpress/securedrop-tooling/issues/5>.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] CI passes
