### PR TITLE
docs: unpin `bento/ubuntu-20.04`

### DIFF
--- a/docs/virtual_environments.rst
+++ b/docs/virtual_environments.rst
@@ -214,16 +214,11 @@ Set the default Vagrant provider to ``libvirt``:
 
 Convert Vagrant boxes to libvirt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-..
-   See also: securedrop#6497
-
-Convert the VirtualBox image for Focal from ``virtualbox`` to ``libvirt`` format.
-Pending resolution of an `upstream bug <https://github.com/chef/bento/issues/1421>`_,
-we must use an older version of this image.
+Convert the VirtualBox images for Focal from ``virtualbox`` to ``libvirt`` format:
 
 .. code:: sh
 
-   vagrant box add --provider virtualbox bento/ubuntu-20.04 --box-version 202112.19.0
+   vagrant box add --provider virtualbox bento/ubuntu-20.04
    vagrant mutate bento/ubuntu-20.04 libvirt
 
 You can now use the libvirt-backed VM images to develop against


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

freedomofpress/securedrop#6497 is fixed with bento/ubuntu-20.04 202303.13.0, so it's no longer necessary to pin to the last-working version.

* Fixes freedomofpress/securedrop#6497


## Testing

**None needed, but for the record:**  Following the reproduction in chef/bento#1421, observe a unique `/etc/machine-id` for each Vagrant VM:

```sh-session
root@sd-staging:~# vagrant box add --provider=virtualbox bento/ubuntu-20.04
[...]
==> box: Successfully added box 'bento/ubuntu-20.04' (v202303.13.0) for 'virtualbox'!
root@sd-staging:~# vagrant init
root@sd-staging:~# vim Vagrantfile  # config.vm.box = "bento/ubuntu-20.04" 
root@sd-staging:~# vagrant up && vagrant ssh -c "cat /etc/machine-id"
[...]
7e9cb963eee64b9892d8f4f84c789deb
Connection to 127.0.0.1 closed.
root@sd-staging:~# vagrant destroy && vagrant up && vagrant ssh -c "cat /etc/machine-id"
[...]
93176529d8ff433481467e2b62d090cc
```

## Release 

No special considerations.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
