### PR TITLE
Suppress checks of links to private reops; remove a broken link for now

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,6 +321,8 @@ linkcheck_ignore = [
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#announcement",
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#repository",
     "https://github.com/freedomofpress/securedrop-apt-prod",
+    "https://github.com/freedomofpress/securedrop-engineering/issues/6",
+    "https://github.com/freedomofpress/i18n_scan",
     r"https://weblate.securedrop.org/accounts/profile/.*",
     r"https://github.com/freedomofpress/securedrop/issues/.*",
     r"https://github.com/freedomofpress/securedrop/tree/.*",

--- a/docs/release_management.rst
+++ b/docs/release_management.rst
@@ -38,8 +38,7 @@ Pre-Release
    Keep this issue updated as you proceed through the release process for transparency.
 
 #. Copy a link of the latest release or release candidate from the `Tails apt repo
-   <https://deb.tails.boum.org/dists/>`_ and include it in the issue. You can compare it with the
-   `Tails release calendar <https://tails.boum.org/contribute/calendar/>`_ if you're not sure. The
+   <https://deb.tails.boum.org/dists/>`_ and include it in the issue. The
    goal is to make sure we test against the lastest Tails release, including release candidates,
    so that we can report bugs early to Tails.
 

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -7,7 +7,7 @@ Policy on Supported Languages
 
    * - Version
      - Approved
-   * - `5 <https://github.com/freedomofpress/securedrop-engineering/issues/6>`_
+   * - 5 `(internal link) <https://github.com/freedomofpress/securedrop-engineering/issues/6>`_
      - 8 March 2023
 
 
@@ -106,7 +106,7 @@ Then:
    consecutive translation freezes.
 
         #. In consultation with Localization Lab, the Localization
-           Manager MAY consult the `language census`_ and reach out to
+           Manager MAY consult the `language census`_ (internal link) and reach out to
            administrators who may be able to contribute to translation and
            review.
 


### PR DESCRIPTION
## Status
Ready for review 
## Description of Changes

- Satisfies link checker.
- If/when those repos are made public, we can update.
- Also removes the Tails calendar for now, though it should be back soon: https://gitlab.tails.boum.org/tails/tails/-/merge_requests/1188

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
