### PR TITLE
Document new package repository setup

### DIFF
--- a/docs/debian_packages.rst
+++ b/docs/debian_packages.rst
@@ -1,5 +1,5 @@
-SecureDrop apt Repository
-=========================
+Debian packages
+===============
 
 This document contains brief descriptions of the Debian packages
 hosted and maintained by Freedom of the Press Foundation in our apt
@@ -59,7 +59,7 @@ A
 that includes static debug symbols and allows for generating a backtrace or other
 diagnostic information in the event of a crash, for example
 `with gdb <https://wiki.debian.org/HowToGetABacktrace/#Running_gdb>`_. These packages
-have a ``-dbgsym.deb`` suffix on Debian, and a ``-dbgsym.ddeb`` suffix (which we 
+have a ``-dbgsym.deb`` suffix on Debian, and a ``-dbgsym.ddeb`` suffix (which we
 `rename <https://github.com/freedomofpress/securedrop/blob/b7bda4fe7badd5267a829f5bfe243fd13db9178e/builder/build-debs-securedrop.sh#L35-L37>`_
 to to ``-dbgsym.deb`` for consistency) on Ubuntu. These packages are generated
 during the build process for components that include compiled binaries, such as

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,8 @@ administrators <https://docs.securedrop.org/>`_.
    testing_application_tests
    testing_configuration_tests
    demo
-   apt_repo
+   package_repos
+   debian_packages
    updating_ossec
    apparmor_profiles
    portable_demo

--- a/docs/package_repos.rst
+++ b/docs/package_repos.rst
@@ -1,0 +1,68 @@
+Package repositories
+====================
+
+.. warning::
+    This document describes some work that is still in progress and may not be 100% applicable yet.
+
+SecureDrop publishes .deb and .rpm packages via apt and yum repositories, respectively.
+
+Each package repository is maintained in a specific Git LFS repository that is published to `Cloudflare's R2
+static hosting product <https://developers.cloudflare.com/r2/>`__. The Git repository contains the .deb and .rpm files, as well as the repository metadata.
+When a new commit is pushed, GitHub Actions (GHA) publishes the contents of the "public" folder to Cloudflare.
+We use `rclone <https://rclone.org/>`__ for this process to make it mostly vendor-neutral in case we
+need to switch providers in the future.
+
+For historical reasons, the apt repositories are on ``*.freedom.press`` while the yum respositories
+are on ``*.securedrop.org``.
+
+There are three levels of package repositories, which correspond to different stages
+of the development process.
+
+Test repositories
+-----------------
+
+* apt: `apt-test.freedom.press <https://apt-test.freedom.press>`__, via `securedrop-apt-test <https://github.com/freedomofpress/securedrop-apt-test>`__
+* yum: `yum-test.securedrop.org <https://yum-test.securedrop.org>`__, via `securedrop-yum-test <https://github.com/freedomofpress/securedrop-yum-test>`__
+
+Test repositories serve two primary functions. First, during the release process,
+release candidate packages are published here to enable developers to perform QA,
+including testing upgrades.
+
+Second, nightly package builds are automatically pushed to test repositories by CI
+to enable developers to test integrated systems with code straight from `main`.
+
+The signing key for these test repositories is lower-security and stored in GHA. Packages
+are automatically signed by a GHA workflow before being uploaded to Cloudflare.
+
+QA repositories
+---------------
+
+* apt: `apt-qa.freedom.press <https://apt-qa.freedom.press>`__, via `securedrop-apt-prod's release branch <https://github.com/freedomofpress/securedrop-apt-prod/tree/release>`__
+* yum: `yum-qa.securedrop.org <https://yum-qa.securedrop.org>`__, via `securedrop-yum-prod's release branch <https://github.com/freedomofpress/securedrop-yum-prod/tree/release>`__
+
+QA repositories are used as the final QA step before a new version is fully released.
+Developers upload candidate packages (using a non-release candidate version) to the
+`release` branch, and sign the repository using the high-security, offline, SecureDrop signing key.
+
+Once the new packages have been QA'd and approved, the `release` branch is merged into `main`,
+which publishes the packages on the production repositories.
+
+Production repositories
+-----------------------
+
+* apt: `apt.freedom.press <https://apt.freedom.press>`__, via `securedrop-apt-prod's main branch <https://github.com/freedomofpress/securedrop-apt-prod/tree/main>`__
+* yum: `yum.securedrop.org <https://yum.securedrop.org>`__, via `securedrop-yum-prod's main branch <https://github.com/freedomofpress/securedrop-yum-prod/tree/main>`__
+
+Production repositories are used by real deployments of SecureDrop. SecureDrop server
+is configured to automatically fetch and install updates every 24 hours while SecureDrop Workstation
+requires a manual updater run.
+
+This repository is signed using the high-security, offline, SecureDrop signing key.
+
+Historical setup
+----------------
+
+Historically each package repository was hosted on a dedicated virtual server, corresponding to the same Git LFS repositories.
+The Git repository contained the .deb and .rpm files and in some cases, the repository metadata too. When a new commit
+is pushed, a webhook instructed the server to pull new changes. A fallback cron job to git pull the repository also
+ran every 15 minutes.


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->
Ready for review


## Description of Changes

This documents the new, Cloudflare R2-based setup, while keeping the status quo at the bottom under "Historical setup".

The existing apt repo documentation is kept for now because it has good information about stuff like dbgsym packages, but that should be cleaned up in the future.

Fixes #80.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] visual review


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
