### PR TITLE
Use unattended-upgrades for kernel testing

### DIFF
--- a/docs/kernel.rst
+++ b/docs/kernel.rst
@@ -11,7 +11,10 @@ Testing a new kernel
 
 The following steps should be performed for all of the `recommended hardware`_:
 
-#. Install the new kernel packages on your *Monitor Server*, then reboot. Verify with ``uname -r`` that you are using the new kernel.
+#. Install the new kernel packages on your *Monitor Server* using unattended-upgrades,
+   e.g. ``sudo apt update && sudo unattended-upgrades --debug`` or wait for the automatic
+   nightly upgrade.
+#. Reboot. Verify with ``uname -r`` that you are using the new kernel.
 #. If it doesn't boot, see the `Troubleshooting Kernel Updates`_ documentation.
 #. Install the ``paxtest`` package, run with ``sudo paxtest blackhat``, and verify it doesn't
    return any new errors nor warnings.


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

Document the use of unattended-upgrades for kernel testing.

There are subtle differences between `apt upgrade` and `unattended-upgrades` so let's prefer the latter while testing since that's what production SecureDrops do.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] Visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* no


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
