### PR TITLE
Add instructions for upgrading our Rust toolchain

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ administrators <https://docs.securedrop.org/>`_.
    release_management
    build_metadata
    kernel
+   rust_toolchain
    updating_tor
 
 .. toctree::

--- a/docs/rust_toolchain.rst
+++ b/docs/rust_toolchain.rst
@@ -1,0 +1,32 @@
+Rust toolchain maintenance
+==========================
+
+Unlike Python, which we get from Debian packages, we manage our own Rust toolchain
+in the SecureDrop server dev environment and package builder.
+
+Rust releases new versions every 6 weeks. We aim to stay within 2-3 versions of the
+latest stable release, which allows us to update (at minimum) every 3-5 months.
+
+Upgrading the toolchain
+-----------------------
+
+The Rust version is specified in a number of files, including:
+
+* ``rust-toolchain.toml``
+* Package builder's ``Dockerfile``
+* Dev environment's ``Dockerfile``
+* CI manifests
+
+It is recommended to grep for the old version string to find any other places
+it might also be used.
+
+As of this writing, Rust code is used by Sequoia-PGP ``redwood`` bridge and ``cryptography``
+dependency. The following test plan can be used for smoke testing those:
+
+.. code:: markdown
+
+    * [ ] CI passes, including deb building and staging build
+    * [ ] Build new debs, deploy on a staging/prod instance:
+       * [ ] Create a new source, upload a file.
+       * [ ] Create new journalist, log in as them.
+       * [ ] As the journalist, download the file and successfully decrypt it.


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

We're responsible for keeping the Rust toolchain up to date, so add some rough guidelines and instructions.

The test plan is based off of
<https://github.com/freedomofpress/securedrop/pull/6832>.

Fixes #79.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* Visual review

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
