### PR TITLE
Update dev instructions to refer to fedora-38-dvm

### DIFF
--- a/docs/qubes_staging.rst
+++ b/docs/qubes_staging.rst
@@ -169,12 +169,12 @@ Inter-VM networking
 
 We want to be able to SSH connections from ``sd-dev`` to these new standalone VMs.
 In order to do so, we have to adjust the firewall rules. Make the following changes on
-``fedora-37-dvm``, which is the template for ``sys-firewall`` under a default setup.
+``fedora-38-dvm``, which is the template for ``sys-firewall`` under a default setup.
 
 .. note::
 
    These changes to the firewall rules will also apply to all other DispVMs based off
-   ``fedora-37-dvm``, and are meant for a testing/development machine only.
+   ``fedora-38-dvm``, and are meant for a testing/development machine only.
 
 Let's get the IP address of ``sd-dev``. On ``dom0``:
 
@@ -182,7 +182,7 @@ Let's get the IP address of ``sd-dev``. On ``dom0``:
 
    qvm-prefs sd-dev ip
 
-Get a shell on ``fedora-37-dvm``. Create or edit
+Get a shell on ``fedora-38-dvm``. Create or edit
 ``/rw/config/qubes-firewall-user-script``, to include the following:
 
 .. code:: sh
@@ -196,7 +196,7 @@ Get a shell on ``fedora-37-dvm``. Create or edit
    iptables -I FORWARD 2 -s "$sd_app" -d "$sd_mon" -j ACCEPT
    iptables -I FORWARD 2 -s "$sd_mon" -d "$sd_app" -j ACCEPT
 
-Shut down ``fedora-37-dvm``, then restart ``sys-firewall``.
+Shut down ``fedora-38-dvm``, then restart ``sys-firewall``.
 
 Now from ``sd-dev``, you should be able to do
 

--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -193,7 +193,7 @@ in dom0 will be overwritten by ``make dev``.
 Staging Environment
 -------------------
 
-Update ``dom0``, ``fedora-37``, ``whonix-gw-16`` and ``whonix-ws-16`` templates
+Update ``dom0``, ``fedora-38``, ``whonix-gw-16`` and ``whonix-ws-16`` templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Updates to these VMs will be performed by the installer and updater, but


### PR DESCRIPTION
## Status

Staying in draft mode til f38 changes are live

## Description of Changes

* Description: Replace references to fedora-37-dvm with fedora-38-dvm in dev docs

* Towards https://github.com/freedomofpress/securedrop-workstation/issues/892

## Testing
* visual review, CI passes

## Release 
* n/a 

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
