### PR TITLE
Update reference from debian-10 to debian-11 standalone VM in dev docs 

### DIFF
--- a/docs/qubes_staging.rst
+++ b/docs/qubes_staging.rst
@@ -13,7 +13,7 @@ accurately for Tor to start and hidden services to be available.
 Overview
 --------
 Follow the Qubes platform instructions in :doc:`setup_development`
-to create a Debian 10 ``sd-dev`` Standalone VM. Once done, we'll create three new
+to create a Debian 11 ``sd-dev`` Standalone VM. Once done, we'll create three new
 Standalone (HVM) Qubes VMs for use with staging:
 
 - ``sd-staging-base-focal``, a base VM for cloning reusable staging VMs


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Description: s/Debian 10/Debian 11 in dev docs

* Resolves n/a

* Related Issues n/a

## Testing
* visual review, CI passes

## Release 
* n/a


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
