### PR TITLE
Update python:3.9-slim-bullseye image sha, and switch to nginx:mainline-alpine-slim

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
-# sha256 as of 2023-01-17
-FROM python:3.9-slim-bullseye@sha256:8b0502fe3a8ae9d26567f66e217223595ff6abe901cba64fd8b1b58176311b27 AS sphinx
+# sha256 as of 2023-10-16
+FROM python:3.9-slim-bullseye@sha256:b3415be51b8d2c8f35a6eb3db85e9ccdedf12beaa3b18ed4c2f769889717d02a as sphinx
 
 ARG GIT_BRANCH=main
 RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra
@@ -8,8 +8,8 @@ RUN pip install poetry==1.4.0
 RUN poetry install
 RUN deploy/build $GIT_BRANCH
 
-# sha256 as of 2023-01-09
-FROM nginx:mainline-alpine@sha256:c1b9fe3c0c015486cf1e4a0ecabe78d05864475e279638e9713eb55f013f907f
+# sha256 as of 2023-10-16
+FROM nginx:mainline-alpine-slim@sha256:1b0cb433e90260a96528c987ee78b797e842d510473935304a0931536d10f50d
 
 COPY deploy/nginx.conf /etc/nginx
 RUN mkdir -p /opt/nginx/run /opt/nginx/webroot/en/latest && chown -R nginx:nginx /opt/nginx


### PR DESCRIPTION
Equivalent of https://github.com/freedomofpress/securedrop-docs/pull/510