### PR TITLE
Update SDW Debian package release instructions

### DIFF
--- a/docs/workstation_development.rst
+++ b/docs/workstation_development.rst
@@ -94,12 +94,12 @@ Building the Templates
 To build the base template, please follow the instructions in
 https://github.com/freedomofpress/qubes-template-securedrop-workstation
 
-Building workstation deb packages
----------------------------------
+Building workstation Debian packages
+------------------------------------
 
 Debian packages for the SecureDrop Workstation components are maintained
 in a separate repository:
-https://github.com/freedomofpress/securedrop-builder/
+https://github.com/freedomofpress/securedrop-client/
 
 Building workstation rpm packages
 ---------------------------------


### PR DESCRIPTION

## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

This contains an update for two major changes:

### Switch to monorepo

All components are now built together via the client repo, so all changes happen there first and the builder repository is just needed for localwheels.

We also do a changelog bump in between the last RC and the actual prod package, so there is no expectation and workarounds to keep the checksum the same across the two.

### Building in containers

Per <https://github.com/freedomofpress/securedrop-engineering/pull/20>, as long as the package is reproducible, we can build it inside a container instead of a dispVM. The instructions still require a fresh clone, but the build script will transparently take care of the containerization part. An explicit step is added for having another maintainer check the package is actually reproducible.

### Misc. hanges

I removed language related to timelines given that we don't actually want releases to take several weeks, nor have they recently.

Fixes #134.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [x] visual review
* [x] Look around the repo to make sure there's no other outdated stuff

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
