### PR TITLE
Update documentation to refer to Qubes 4.2

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -25,10 +25,9 @@ If you'd like to chat with other developers working on the client drop
 into our `Gitter chat channel for the project <https://gitter.im/freedomofpress/securedrop>`_.
 
 Every non-public holiday weekday (except Fridays) at 10am (Pacific Time) we
-take part in a public daily stand-up, usually via a
-`meeting on Google Meet <https://meet.google.com/ekb-kkhf-mrk>`_
-(although the details of each daily meeting are published on the Gitter channel
-five minutes before the start of the meeting). All are welcome to contribute.
+take part in a public daily stand-up, usually via a meeting on Google Meet.
+Connection information for standups is published periodically on the Gitter channel.
+All are welcome to contribute.
 
 Otherwise, read on.
 

--- a/docs/includes/squash-commits.txt
+++ b/docs/includes/squash-commits.txt
@@ -1,12 +1,10 @@
 
-.. note:: 
+.. note::
           It is generally good practice to maintain a clean git history by
-          reducing the number of commits to a reasonable minimum. You can do 
-          this by squashing closely related commits through an interactive 
-          rebase once your PR is close to being merged. If you are unfamiliar 
-          with how to squash commits with rebase, check out this 
-          `blog post <http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html>`__.
+          reducing the number of commits to a reasonable minimum. You can do
+          this by squashing closely related commits through an interactive
+          rebase once your PR is close to being merged.
 
-          If you would like a project maintainer to help you with squashing 
+          If you would like a project maintainer to help you with squashing
           commits in a PR, please don't hesitate to leave a comment requesting
           assistance.

--- a/docs/workstation_development.rst
+++ b/docs/workstation_development.rst
@@ -88,12 +88,6 @@ The ``make clone`` command will build a new version of the RPM package
 that contains the provisioning logic in your development VM (e.g.,
 ``sd-dev``) and copy it to ``dom0``.
 
-Building the Templates
-----------------------
-
-To build the base template, please follow the instructions in
-https://github.com/freedomofpress/qubes-template-securedrop-workstation
-
 Building workstation Debian packages
 ------------------------------------
 

--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -5,7 +5,7 @@ is a project currently in the beta stages of software development which aims to
 improve journalists' experience working with SecureDrop while retaining
 the current security and privacy features SecureDrop provides.
 
-Installing the project requires an up-to-date Qubes 4.1 installation
+Installing the project requires an up-to-date Qubes 4.2 installation
 running on a machine with at least 16GB of RAM (32 GB recommended).
 You'll need access to a SecureDrop staging server as well.
 
@@ -18,7 +18,7 @@ Install Qubes
 -------------
 
 Before trying to use this project, install `Qubes
-4.1.2 <https://www.qubes-os.org/downloads/>`__ on your development
+4.2.1 <https://www.qubes-os.org/downloads/>`__ on your development
 machine. Accept the default VM configuration during the install process.
 
 After installing Qubes, you must update both dom0 and the base templates
@@ -193,8 +193,8 @@ in dom0 will be overwritten by ``make dev``.
 Staging Environment
 -------------------
 
-Update ``dom0``, ``fedora-38``, ``whonix-gw-16`` and ``whonix-ws-16`` templates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Update ``dom0``, ``fedora-39``, ``whonix-gateway-17`` and ``whonix-workstation-17`` templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Updates to these VMs will be performed by the installer and updater, but
 updating them prior to install makes it easier to debug any errors.
@@ -204,10 +204,9 @@ bootstrap to the Tor network. In the Qubes menu, navigate to
 ``sys-whonix`` and click on ``Anon Connection Wizard`` and click
 ``Next`` and ensure the Tor Bootstrap process completes successfully.
 
-In the Qubes Menu, navigate to ``System Tools`` and click on
-``Qubes Update``. Click the
-``Enable updates for qubes without known available updates`` and select
-all VMs in the list. Click on ``Next`` and wait for updates to complete.
+In the Qubes Menu, select the cog icon to access the Settings submenu,
+navigate to ``Qubes Tools`` and click on ``Qubes Update``. In the updater,
+select all VMs in the list, then click  ``Next`` and wait for updates to complete.
 
 Choose your installation method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -251,7 +250,7 @@ contents:
 
    [securedrop-workstation-temporary]
    enabled=1
-   baseurl=https://yum-test.securedrop.org/workstation/dom0/f32
+   baseurl=https://yum-test.securedrop.org/workstation/dom0/f37
    name=SecureDrop Workstation Qubes initial install bootstrap
 
 3. Download the RPM package
@@ -266,14 +265,14 @@ The RPM file will be downloaded to your current working directory.
 
 ::
 
-   [user@work ~]$ rpm -Kv securedrop-workstation-dom0-config-x.y.z-1.fc32.noarch.rpm
+   [user@work ~]$ rpm -Kv securedrop-workstation-dom0-config-x.y.z-1.fc37.noarch.rpm
 
 The output should match the following, and return ``OK`` for all lines
 as follows:
 
 ::
 
-   securedrop-workstation-dom0-config-x.y.z-1.fc32.noarch.rpm:
+   securedrop-workstation-dom0-config-x.y.z-1.fc37.noarch.rpm:
        Header V4 RSA/SHA256 Signature, key ID 2211b03c: OK
        Header SHA1 digest: OK
        V4 RSA/SHA256 Signature, key ID 2211b03c: OK
@@ -288,7 +287,7 @@ its current value):
 
 ::
 
-   [dom0]$ qvm-run --pass-io work 'cat /home/user/securedrop-workstation-dom0-config-x.y.z-1.fc32.noarch.rpm' > securedrop-workstation.rpm
+   [dom0]$ qvm-run --pass-io work 'cat /home/user/securedrop-workstation-dom0-config-x.y.z-1.fc37.noarch.rpm' > securedrop-workstation.rpm
    sudo dnf install securedrop-workstation.rpm
 
 The provisioning scripts and tools should now be in place, and you can


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

* Description: 

- Updates workstation setup docs to reference Qubes 4.2 instead of 4.1
- removes a few broken links while I'm in here.

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
