### PR TITLE
`make` no longer needs to be manually installed in dom0

### DIFF
--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -22,14 +22,12 @@ Before trying to use this project, install `Qubes
 machine. Accept the default VM configuration during the install process.
 
 After installing Qubes, you must update both dom0 and the base templates
-to include the latest versions of apt packages, as well as install an
-additional dependency (``make``) in dom0. Open a terminal in
+to include the latest versions of apt packages. Open a terminal in
 ``dom0`` by clicking on the Qubes menu top-right of the screen and
 left-clicking on Terminal Emulator and run:
 
 ::
 
-   sudo qubes-dom0-update -y make
    sudo qubes-dom0-update
 
 After dom0 updates complete, reboot your computer to ensure the updates


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

It comes pre-installed in Qubes 4.2.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] visual review (unless you really want to do a fresh install of 4.2 and see that make already is installed :))

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
