### PR TITLE
Migrate to Debian bookworm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,4 +5,5 @@ on: [merge_group, push, pull_request]
 
 jobs:
   reusable:
-    uses: freedomofpress/securedrop-docs/.github/workflows/ci.yml@main
+    # TODO: switch back to main once securedrop-docs is on bookworm
+    uses: freedomofpress/securedrop-docs/.github/workflows/ci.yml@bookworm

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -7,4 +7,5 @@ on:
 
 jobs:
   reusable:
-    uses: freedomofpress/securedrop-docs/.github/workflows/linkcheck.yml@main
+    # TODO: switch back to main once securedrop-docs is on bookworm
+    uses: freedomofpress/securedrop-docs/.github/workflows/linkcheck.yml@bookworm

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,15 +1,14 @@
-# sha256 as of 2023-10-16
-FROM python:3.9-slim-bullseye@sha256:b3415be51b8d2c8f35a6eb3db85e9ccdedf12beaa3b18ed4c2f769889717d02a as sphinx
+# sha256 as of 2024-06-10
+FROM debian:bookworm@sha256:911821c26cc366231183098f489068afff2d55cf56911cb5b7bd32796538dfe1 AS sphinx
 
 ARG GIT_BRANCH=main
-RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra
+RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra python3-poetry
 COPY ./ .
-RUN pip install poetry==1.7.1
 RUN poetry install
 RUN deploy/build $GIT_BRANCH
 
-# sha256 as of 2023-10-16
-FROM nginx:mainline-alpine-slim@sha256:1b0cb433e90260a96528c987ee78b797e842d510473935304a0931536d10f50d
+# sha256 as of 2024-06-10
+FROM nginx:mainline-alpine-slim@sha256:244d37691a469d45349d9f29e8b7462d9f510b70c0c93acc5d23ee227070c962
 
 COPY deploy/nginx.conf /etc/nginx
 RUN mkdir -p /opt/nginx/run /opt/nginx/webroot/en/latest && chown -R nginx:nginx /opt/nginx

--- a/poetry.lock
+++ b/poetry.lock
@@ -180,25 +180,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "7.1.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
-    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
-]
-
-[package.dependencies]
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.4"
 description = "A very fast and expressive template engine."
@@ -384,7 +365,6 @@ babel = ">=2.9"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.18.1,<0.22"
 imagesize = ">=1.3"
-importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.0"
 packaging = ">=21.0"
 Pygments = ">=2.14"
@@ -396,7 +376,6 @@ sphinxcontrib-htmlhelp = ">=2.0.0"
 sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = ">=1.1.9"
-tomli = {version = ">=2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
@@ -550,17 +529,6 @@ standalone = ["Sphinx (>=5)"]
 test = ["pytest"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "tornado"
 version = "6.4.1"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -597,22 +565,7 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
-[[package]]
-name = "zipp"
-version = "3.19.2"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
-    {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
-]
-
-[package.extras]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
-
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "f2692a27ed44b846c3c0d73fbcc81e5dc3018ce965fac7bd50ed69c11e1da603"
+python-versions = "^3.11"
+content-hash = "ebd2081bf3a7de4afff9c5ea44a4a8c5ea61be4634ef8f67484241cc99f44dbd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["SecureDrop team <securedrop@freedom.press>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.11"
 sphinx = "^7.3.7"
 sphinx-autobuild = "^2024.2.4"
 sphinx-rtd-theme = "^2.0.0"


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Install poetry from Debian packages
* Build deployment content in a Debian container instead of Python. This shouldn't make much of a difference except that we'll also get security updates of Python itself from Debian instead of needing to bump the image (which we haven't really been doing).
* Bump the nginx alpine image to latest.

Refs <https://github.com/freedomofpress/securedrop-docs/issues/567>.


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [x] Run `podman build --build-arg GIT_BRANCH=$(git rev-parse HEAD) --file deploy/Dockerfile . -t dev-docs` (or `docker` is fine too), finishes successfully
* [x] Run `podman run --rm -p 5080:5080 dev-docs`, visit localhost:5080 in your browser and test basic functionality
   * [x] viewing pages looks fine
   * [x] search works correctly
   * [x] PDF looks good

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
