### PR TITLE
Switch CI reusable workflows back to main branch on `securedrop-docs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,5 +5,4 @@ on: [merge_group, push, pull_request]
 
 jobs:
   reusable:
-    # TODO: switch back to main once securedrop-docs is on bookworm
-    uses: freedomofpress/securedrop-docs/.github/workflows/ci.yml@bookworm
+    uses: freedomofpress/securedrop-docs/.github/workflows/ci.yml@main

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -7,5 +7,4 @@ on:
 
 jobs:
   reusable:
-    # TODO: switch back to main once securedrop-docs is on bookworm
-    uses: freedomofpress/securedrop-docs/.github/workflows/linkcheck.yml@bookworm
+    uses: freedomofpress/securedrop-docs/.github/workflows/linkcheck.yml@main


### PR DESCRIPTION
CI expected to fail until https://github.com/freedomofpress/securedrop-docs/pull/574 lands.