### PR TITLE
Document updated main/nightly component configuration for apt-test

### DIFF
--- a/docs/workstation_development.rst
+++ b/docs/workstation_development.rst
@@ -60,7 +60,9 @@ Automatic updates
 Double-clicking the “SecureDrop” desktop icon will launch a preflight
 updater that applies any necessary updates to VMs, and may prompt a
 reboot. In a development environment, this will install the latest
-nightly packages, and the latest RPM published to ``yum-test``.
+nightly packages (unless a package with a higher version number is
+available on ``apt-test`` in ``main``), and the latest RPM published
+to  ``yum-test``.
 
 Manually updating dom0 code
 ---------------------------

--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -50,10 +50,15 @@ instructions:
 
 -  The development environment uses the ``yum-test.securedrop.org`` and
    ``apt-test.freedom.press`` repositories, and is configured to use the
-   ``nightly`` component for apt package. It does not alter power
-   management settings on your laptop to prevent suspension to disk (a
-   security measure for production environments, which the staging
-   environment preserves to be more faithful to prod-like settings).
+   ``nightly`` and ``main`` components for apt packages. This means it
+   will install nightly packages, unless a package is only available
+   in ``main``, or a version with a higher version number has been
+   published there.
+
+   This configuration does not alter your management settings on your
+   laptop to prevent suspension to disk (a security measure for
+   production environments, which the staging environment preserves
+   to be more faithful to prod-like settings).
 
 -  The production environment uses ``yum.securedrop.org`` and
    ``apt.freedom.press`` repositories, verified using the production


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

https://github.com/freedomofpress/securedrop-workstation/pull/970 added main to the list of components for apt-test.freedom.press in a dev environment. This changes the behavior and will install more recent packages from main when they're available (as is the case of this writing with RC1 of https://apt-test.freedom.press/pool/main/s/securedrop-client/securedrop-client_0.11.0~rc1%2Bbookworm_all.deb). Documenting this to avoid confusion.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
