### PR TITLE
Remove most references to the SecureDrop forum

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,7 +317,6 @@ linkcheck_workers = 32
 linkcheck_ignore = [
     r"http://127.0.0.1(:\d+)?/?",
     r"http://localhost(:\d+)?/?",
-    "https://forum.securedrop.org/admin/users/list/active",
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#announcement",
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#repository",
     "https://github.com/freedomofpress/securedrop-apt-prod",

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -11,13 +11,10 @@ are a variety of ways to help. We are always looking for help from:
 * `UX contributors`_, to help improve the product experience for end users;
 * `Translators`_, to translate SecureDrop;
 * `Release managers`_, to create and maintain Debian GNU/Linux packages and repositories;
-* `Forum moderators and support`_ volunteers, to help with the support forums.
 
 You can always find a regular project contributor to answer any questions you
 may have on the `SecureDrop instant messaging channel
-<https://gitter.im/freedomofpress/securedrop>`__. You can also register on `the
-forum <https://forum.securedrop.org/>`__ for more information and to
-participate in longer discussions.
+<https://gitter.im/freedomofpress/securedrop>`__.
 
 
 .. note::
@@ -168,10 +165,9 @@ another language, we would welcome your help.
 
 SecureDrop is translated using `Weblate
 <https://weblate.securedrop.org/>`__. We provide a :doc:`detailed
-guide <translations>` for translators, and feel free to contact us in the
-`translation section of the SecureDrop forum
-<https://forum.securedrop.org/c/translations>`__ for help. Non-English
-forum discussions are also welcome.
+guide <translations>` for translators, and feel free to contact us in our
+`Gitter chat room <https://gitter.im/freedomofpress/securedrop>`__ or through Localization Lab
+communications platforms.
 
 |SecureDrop translation status|
 
@@ -182,23 +178,3 @@ forum discussions are also welcome.
 
 .. |SecureDrop language status| image:: https://weblate.securedrop.org/widgets/securedrop/-/horizontal-auto.svg
    :alt: SecureDrop language status
-
-
-
-Forum Moderators and Support
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Those running a production instance of SecureDrop are encouraged to `read the
-support documentation <https://support-docs.securedrop.org/>`__ to get
-help from the `Freedom of the Press Foundation <https://freedom.press>`__. For
-less sensitive topics such as running a demo or getting help to understand a
-concept, a `public forum section <https://forum.securedrop.org/c/support>`__ is
-better suited. To assist on the forum:
-
-* Look for `the latest unanswered questions in the
-  <https://forum.securedrop.org/c/support>`__ forum and answer them.
-* If you find questions `elsewhere in the forum
-  <https://forum.securedrop.org>`__ that have a better chance at
-  getting an answer in the `support section
-  <https://forum.securedrop.org/c/support>`__, suggest in Gitter
-  to move topics from a category to another.

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -237,7 +237,6 @@ release.
 Then, the localization manager for the release will:
 
 * `Update Weblate screenshots`_ so translators can see new or modified source strings in context.
-* Update the `i18n timeline`_ in the translation section of the forum.
 * Add a `Weblate announcement`_ for the ``securedrop/securedrop`` component with
   the translation timeline for the release.
 
@@ -297,7 +296,6 @@ Then, post-release, either same day or day-after, the localization manager shoul
 
 * Remove the `Weblate announcement`_ about this release's translation timeline
   (if you set an end-date on the original announcement, this may happen automatically)
-* Update the `i18n timeline`_ in the forum.
 * Update the `tracking spreadsheet`_ with supported languages' current
   translation and review coverage.  File a ticket for each new language due
   either (a) consideration for new support, (b) probation for dropping coverage,
@@ -344,7 +342,6 @@ Admin permissions
 The full set of admin permissions can be granted at:
 
 * https://weblate.securedrop.org/admin/weblate_auth/user/ (grant staff and superuser status)
-* https://forum.securedrop.org/admin/users/list/active (click on the user and ``Grant Moderation``)
 * https://github.com/freedomofpress/securedrop-i18n (make sure that the user has commit access)
 
 Granting reviewer privileges in Weblate
@@ -391,7 +388,6 @@ with a release looming, the server can be rebooted.
 .. _`Weblate translation creation page`: https://weblate.securedrop.org/new-lang/securedrop/securedrop/
 .. _`Weblate desktop translation creation page`: https://weblate.securedrop.org/new-lang/securedrop/desktop/
 .. _`Weblate makes it easy to list the translators`: https://docs.weblate.org/en/latest/devel/reporting.html
-.. _`i18n timeline`: https://forum.securedrop.org/t/about-the-translations-category/16
 .. _`Weblate announcement`: https://weblate.securedrop.org/projects/securedrop/securedrop/#announcement
 .. _`Django admin panel`: https://weblate.securedrop.org/admin/trans/announcement/
 .. _`i18n.json`: https://github.com/freedomofpress/securedrop/blob/develop/securedrop/i18n.json

--- a/docs/release_management.rst
+++ b/docs/release_management.rst
@@ -324,8 +324,7 @@ Post-Release
 
    #. Make a PR to merge these changes into ``develop``.
 
-#. Monitor the `FPF support portal <https://support.freedom.press>`_ and the
-   `SecureDrop community support forum <https://forum.securedrop.org/c/support>`_ for any new user
+#. Monitor the `FPF support portal <https://support.freedom.press>`_ for any new user
    issues related to the release.
 
 .. _tails_only_releases:

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -28,7 +28,6 @@ Getting help
 If you're interested in helping with translation and have questions
 about anything in this document, here's how to ask for help:
 
-* Post a message in the `translations category of the SecureDrop forum`_
 * Chat in the `SecureDrop instant messaging channel`_
 
    * `Localization Lab`_, with whom we coordinate SecureDrop's translation, also
@@ -576,7 +575,6 @@ are never translated.
 .. _`SecureDrop Weblate instance`: https://weblate.securedrop.org/
 .. _`Weblate registration page`: https://weblate.securedrop.org/accounts/register/
 .. _`Weblate dashboard`: https://weblate.securedrop.org/
-.. _`translations category of the SecureDrop forum`: https://forum.securedrop.org/c/translations
 .. _`SecureDrop instant messaging channel`: https://gitter.im/freedomofpress/securedrop
 .. _`Weblate documentation`: https://docs.weblate.org/
 .. _`EFF Surveillance Self-Defense glossary`: https://ssd.eff.org/en/glossary/


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

It is still referenced in sections about becoming a SD maintainer and Weblate admin, which can be addressed in a follow-up PR.



## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
