### PR TITLE
Document `make dev-tor` as viable workstation server

### DIFF
--- a/docs/setup_development.rst
+++ b/docs/setup_development.rst
@@ -137,6 +137,7 @@ To get started, you can try the following:
 
    cd securedrop
    make dev                                               # run development servers
+   make dev-tor                                           # run development servers (onion addresses)
    make test                                              # run tests
    securedrop/bin/dev-shell bin/run-test tests/functional # functional tests only
    securedrop/bin/dev-shell bash                          # shell inside the container

--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -7,7 +7,6 @@ the current security and privacy features SecureDrop provides.
 
 Installing the project requires an up-to-date Qubes 4.2 installation
 running on a machine with at least 16GB of RAM (32 GB recommended).
-You'll need access to a SecureDrop staging server as well.
 
 The project is currently in a closed beta, and we do not recommend
 installing it for production purposes. Documentation for end users is
@@ -81,27 +80,7 @@ Decide on a VM to use for development. We recommend creating a
 standalone VM called ``sd-dev`` by following `these
 instructions <https://developers.securedrop.org/en/latest/setup_development.html#qubes>`__.
 
-Clone this repo to your preferred location on that VM.
-
-Next we need to do some SecureDrop-specific configuration:
-
--  Create a ``config.json`` file based on ``config.json.example`` and
-   include your values for the hidserv fields: ``hostname`` (the
-   Journalist Interface Onion URL) and ``key`` (the private key for
-   client authentication). Set ``submission_key_fpr`` to the submission
-   key fingerprint.
-
-   -  On your Admin Workstation, you can find the Journalist Interface
-      onion address and private key in
-      ``~/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private``,
-      and the submission key fingerprint in
-      ``~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific``
-      (``securedrop_app_gpg_fingerprint``).
-
--  Create an ``sd-journalist.sec`` file in the root directory with the
-   ASCII-armored GPG private key used to encrypt submissions in your
-   test SecureDrop instance. The included key ``sd-journalist.sec`` is
-   the one used by default in the SecureDrop staging instance.
+Clone the `securedrop-workstation` repo to your preferred location on that VM.
 
 Qubes provisioning is handled by Salt on ``dom0``, so this project must
 be copied there from your development VM.
@@ -144,6 +123,61 @@ also run this command in ``dom0``:
 
 Doing so will permit the ``sd-dev`` AppVM to make RPC calls with the
 same privileges as the ``sd-app`` AppVM.
+
+
+Run Development SecureDrop Server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here, you will setup a development version of the SecureDrop server to
+which your workstation will connect. Alternatively, you can setup
+:doc:`virtualized staging environments on Qubes OS <virtual_environments>`,
+which is slightly more involved.
+
+- Setup a :doc:`SecureDrop (server) development environment <setup_development>` on Qubes.
+
+.. note:: You will need to run the following step every time that you want
+   to login on SecureDrop client.
+
+- Start the securedrop server in ``sd-dev`` qube with use ``make dev-tor``
+
+
+Configure the Workstation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the output of the `make dev-tor` command ran in the previous section, there
+should be a section that looks like this:
+
+::
+
+   {
+      "submission_key_fpr": "65A1B5FF195B56353CC63DFFCC40EF1228271441",
+      "hidserv": {
+         "hostname": "jpweqok4r43xp4si5pattodglw2btdqlpz2utvn4mkwnx2iwbmp4v2id.onion",
+         "key": "DAZHRYYKWHQCIRUMEVIRSOUZA4MKU4C7WPDWLIVB3TMZWZH2V5MA"
+      },
+      "environment": "prod",
+      "vmsizes": {
+         "sd_app": 10,
+         "sd_log": 5
+      }
+   }
+
+Save this text in the file ``securedrop-workstation/config.json``.
+
+Next, set the default encryption key (for development purposes only):
+
+::
+
+   cd securedrop-workstation
+   cp sd-journalist.sec.example sd-journalist.sec
+
+Then, in ``dom0``, clone the workstation again, to obtain these new files:
+
+::
+
+   [dom0]$ cd ~/securedrop-workstation/
+   [dom0]$ make clone
+
 
 Provision the VMs
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

* Description:  Now that `make dev-tor` [is persistent](https://github.com/freedomofpress/securedrop/issues/7115), it is suitable for workstation development. This treats it as the default option, since the alternative is to setup staging VMs which is much more complicated with essentially no upsides. However, the previous Qubes staging instructions still remain under `qubes_staging.rst`.


* Resolves #
<!-- Add an issue number immediately after the # symbol to link to an existing issue report --> 

* Related Issues
<!-- List any other unresolved, but relevant issues that this PR addresses -->


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed (unrelated breakage)
- [x] You have previewed (`make docs`) docs at http://localhost:8000
