### PR TITLE
Remove obsolete reference to forum

### DIFF
--- a/docs/contributor_guidelines.rst
+++ b/docs/contributor_guidelines.rst
@@ -208,7 +208,7 @@ Git History
 -----------
 
 We currently use an explicit merge strategy to merge feature branches into
-``develop``. 
+``develop``.
 
 .. include:: includes/squash-commits.txt
 
@@ -227,8 +227,8 @@ contributor with the right technical and social skills is entitled to
 ask. The people who have the power to grant such privileges are
 committed to do so in a transparent way as follows:
 
-#. The contributor posts a message `in the forum
-   <https://forum.securedrop.org/>`__ asking for privileges (review or
+#. The contributor posts a message `on Gitter
+   <https://app.gitter.im/#/room/#freedomofpress_securedrop:gitter.im>`__ asking for privileges (review or
    merge, etc.).
 #. After at least a week someone with permissions to grant such
    privilege reviews the thread and either:

--- a/docs/contributor_guidelines.rst
+++ b/docs/contributor_guidelines.rst
@@ -228,7 +228,7 @@ ask. The people who have the power to grant such privileges are
 committed to do so in a transparent way as follows:
 
 #. The contributor posts a message `on Gitter
-   <https://app.gitter.im/#/room/#freedomofpress_securedrop:gitter.im>`__ asking for privileges (review or
+   <https://gitter.im/freedomofpress/securedrop>`__ asking for privileges (review or
    merge, etc.).
 #. After at least a week someone with permissions to grant such
    privilege reviews the thread and either:

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -104,7 +104,7 @@ Python code, HTML templates, or desktop icon labels, the translation
 files should also be updated by running ``make extract-strings`` in the root
 of the SecureDrop working copy.
 
-The ``extract-strings`` target gathers source strings, then updates the 
+The ``extract-strings`` target gathers source strings, then updates the
 `.pot`_ files for the SecureDrop server code and the desktop icons.  (This step
 is enforced by CI, which will fail if you skip it.)
 
@@ -321,8 +321,7 @@ Weblate administration
 
 A translation admin has special permissions on `Weblate`_ and the
 repositories. When someone is willing to become an admin, a thread is
-started in `the translation section of the forum
-<https://forum.securedrop.org/c/translations>`_. If there is consensus
+started `on Gitter <https://gitter.im/freedomofpress/securedrop>`_. If there is consensus
 after a week, the permissions of the new admin are elevated. If there
 is not yet consensus, a public vote is organized among the current
 admins.


### PR DESCRIPTION
Point to Gitter for now (GH Discussions not enabled yet, may be in future)

Fixes #214.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
