### PR TITLE
Temporarily track Bookworm CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,4 +5,4 @@ on: [merge_group, push, pull_request]
 
 jobs:
   reusable:
-    uses: freedomofpress/securedrop-docs/.github/workflows/ci.yml@main
+    uses: freedomofpress/securedrop-docs/.github/workflows/ci.yml@bookworm

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   reusable:
-    uses: freedomofpress/securedrop-docs/.github/workflows/linkcheck.yml@main
+    uses: freedomofpress/securedrop-docs/.github/workflows/linkcheck.yml@bookworm


### PR DESCRIPTION
Since this repo re-uses `securedrop-docs` workflows for CI, this temporarily switches it to track a branch still on Bookworm, so https://github.com/freedomofpress/securedrop-docs/pull/663 can safely be merged (the Poetry version in Trixie treats the lack of `package-mode = false` in `pyproject.toml` as a failure).