### PR TITLE
Remove "Historical setup" from package repo docs

### DIFF
--- a/docs/package_repos.rst
+++ b/docs/package_repos.rst
@@ -1,9 +1,6 @@
 Package repositories
 ====================
 
-.. warning::
-    This document describes some work that is still in progress and may not be 100% applicable yet.
-
 SecureDrop publishes .deb and .rpm packages via apt and yum repositories, respectively.
 
 Each package repository is maintained in a specific Git LFS repository that is published to `Cloudflare's R2
@@ -93,11 +90,3 @@ the :doc:`server release management <release_management>` and
 
    We use rclone for this purpose, and in theory are entirely
    vendor neutral and can switch to any another S3-like service.
-
-Historical setup
-----------------
-
-Historically each package repository was hosted on a dedicated virtual server, corresponding to the same Git LFS repositories.
-The Git repository contained the .deb and .rpm files and in some cases, the repository metadata too. When a new commit
-is pushed, a webhook instructed the server to pull new changes. A fallback cron job to git pull the repository also
-ran every 15 minutes.


### PR DESCRIPTION

## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review 


## Description of Changes

* Description: 

It was mostly included since at the time it described the status quo.

We have now fully switched over to R2-hosted repositories, so we can remove it.


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] visual review

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
