### PR TITLE
Document Python and Node.js toolchain usage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ administrators <https://docs.securedrop.org/>`_.
    dependency_updates
    reproducible_builds
    eol_maintenance
+   language_toolchains
 
 .. toctree::
    :caption: SecureDrop Server
@@ -50,7 +51,6 @@ administrators <https://docs.securedrop.org/>`_.
    release_management
    build_metadata
    kernel
-   rust_toolchain
    updating_tor
 
 .. toctree::

--- a/docs/language_toolchains.rst
+++ b/docs/language_toolchains.rst
@@ -1,5 +1,22 @@
-Rust toolchain maintenance
-==========================
+Language toolchains
+===================
+
+Python
+------
+
+In nearly all cases we use the OS-provided version of Python, whether it's Ubuntu,
+Debian or Fedora. In some cases we may also install Python dependencies using OS
+packages, typically when it's something that's hard to build from scratch (e.g.
+Python Qt or GTK bindings).
+
+We rely on the OS for security updates, so we only upgrade major versions when we
+upgrade OS versions.
+
+With Python, we use a mix of ``pip``, ``poetry`` and ``uv`` for package management.
+Older projects may still use ``pip-tools``.
+
+Rust
+----
 
 Unlike Python, which we get from Debian packages, we manage our own Rust toolchain
 in the SecureDrop server dev environment and package builder.
@@ -7,8 +24,8 @@ in the SecureDrop server dev environment and package builder.
 Rust releases new versions every 6 weeks. We aim to stay within 2-3 versions of the
 latest stable release, which allows us to update (at minimum) every 3-5 months.
 
-Upgrading the toolchain
------------------------
+Upgrading
+^^^^^^^^^
 
 The Rust version is specified in a number of files, including:
 
@@ -30,3 +47,14 @@ dependency. The following test plan can be used for smoke testing those:
        * [ ] Create a new source, upload a file.
        * [ ] Create new journalist, log in as them.
        * [ ] As the journalist, download the file and successfully decrypt it.
+
+
+Node.js
+-------
+
+Currently our primary usage of Node.js is with Electron in the
+SecureDrop App (still under development). Electron ships its own
+version of Node.js, so we match that version in CI and elsewhere.
+
+For package management, we are using `pnpm <https://pnpm.io/>`__ largely for its
+better control over build scripts, and because it's generally faster than npm.


### PR DESCRIPTION
Turn the Rust toolchain documentation into a more generic "Language toolchains" page that also covers Python and Node.js.

For Python discuss that we use the OS-provided versions and update on that cycle.

For Node.js, we're primarily using it in the context of Electron, so we'll use the version it provides. Also we're using pnpm.

Fixes #245.



## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits