### PR TITLE
Improve dark mode code block contrast with Pygments themes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ docs-linkcheck:  ## Check documentation for broken links.
 	@make clean && poetry run sphinx-build -b linkcheck -Wn docs/ docs/_build/html
 	@echo
 
+.PHONY: pygments-css
+pygments-css:  ## Generate Pygments dark theme CSS for syntax highlighting.
+	@echo "███ Generating Pygments dark theme CSS..."
+	@poetry run python extract_css.py lightbulb
+	@echo
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %:

--- a/docs/_static/pygments_dark.css
+++ b/docs/_static/pygments_dark.css
@@ -1,0 +1,88 @@
+/* Pygments lightbulb theme - only applied in dark mode */
+@media (prefers-color-scheme: dark) {
+pre { line-height: 125%; }
+td.linenos .normal { color: #3c4354; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #3c4354; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #3c4354; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #3c4354; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #6e7681 }
+.highlight { background: #1d2331; color: #D4D2C8 }
+.highlight .c { color: #7E8AA1 } /* Comment */
+.highlight .err { color: #F88F7F } /* Error */
+.highlight .esc { color: #D4D2C8 } /* Escape */
+.highlight .g { color: #D4D2C8 } /* Generic */
+.highlight .k { color: #FFAD66 } /* Keyword */
+.highlight .l { color: #D5FF80 } /* Literal */
+.highlight .n { color: #D4D2C8 } /* Name */
+.highlight .o { color: #FFAD66 } /* Operator */
+.highlight .x { color: #D4D2C8 } /* Other */
+.highlight .p { color: #D4D2C8 } /* Punctuation */
+.highlight .ch { color: #F88F7F; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #7E8AA1 } /* Comment.Multiline */
+.highlight .cp { color: #FFAD66; font-weight: bold } /* Comment.Preproc */
+.highlight .cpf { color: #7E8AA1 } /* Comment.PreprocFile */
+.highlight .c1 { color: #7E8AA1 } /* Comment.Single */
+.highlight .cs { color: #7E8AA1; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #F88F7F; background-color: #3D1E20 } /* Generic.Deleted */
+.highlight .ge { color: #D4D2C8; font-style: italic } /* Generic.Emph */
+.highlight .ges { color: #D4D2C8 } /* Generic.EmphStrong */
+.highlight .gr { color: #F88F7F } /* Generic.Error */
+.highlight .gh { color: #D4D2C8 } /* Generic.Heading */
+.highlight .gi { color: #6AD4AF; background-color: #19362C } /* Generic.Inserted */
+.highlight .go { color: #7E8AA1 } /* Generic.Output */
+.highlight .gp { color: #D4D2C8 } /* Generic.Prompt */
+.highlight .gs { color: #D4D2C8; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #D4D2C8 } /* Generic.Subheading */
+.highlight .gt { color: #F88F7F } /* Generic.Traceback */
+.highlight .kc { color: #FFAD66 } /* Keyword.Constant */
+.highlight .kd { color: #FFAD66 } /* Keyword.Declaration */
+.highlight .kn { color: #FFAD66 } /* Keyword.Namespace */
+.highlight .kp { color: #FFAD66 } /* Keyword.Pseudo */
+.highlight .kr { color: #FFAD66 } /* Keyword.Reserved */
+.highlight .kt { color: #73D0FF } /* Keyword.Type */
+.highlight .ld { color: #D5FF80 } /* Literal.Date */
+.highlight .m { color: #DFBFFF } /* Literal.Number */
+.highlight .s { color: #D5FF80 } /* Literal.String */
+.highlight .na { color: #FFD173 } /* Name.Attribute */
+.highlight .nb { color: #FFD173 } /* Name.Builtin */
+.highlight .nc { color: #73D0FF } /* Name.Class */
+.highlight .no { color: #FFD173 } /* Name.Constant */
+.highlight .nd { color: #7E8AA1; font-weight: bold; font-style: italic } /* Name.Decorator */
+.highlight .ni { color: #95E6CB } /* Name.Entity */
+.highlight .ne { color: #73D0FF } /* Name.Exception */
+.highlight .nf { color: #FFD173 } /* Name.Function */
+.highlight .nl { color: #D4D2C8 } /* Name.Label */
+.highlight .nn { color: #D4D2C8 } /* Name.Namespace */
+.highlight .nx { color: #D4D2C8 } /* Name.Other */
+.highlight .py { color: #FFD173 } /* Name.Property */
+.highlight .nt { color: #5CCFE6 } /* Name.Tag */
+.highlight .nv { color: #D4D2C8 } /* Name.Variable */
+.highlight .ow { color: #FFAD66 } /* Operator.Word */
+.highlight .pm { color: #D4D2C8 } /* Punctuation.Marker */
+.highlight .w { color: #D4D2C8 } /* Text.Whitespace */
+.highlight .mb { color: #DFBFFF } /* Literal.Number.Bin */
+.highlight .mf { color: #DFBFFF } /* Literal.Number.Float */
+.highlight .mh { color: #DFBFFF } /* Literal.Number.Hex */
+.highlight .mi { color: #DFBFFF } /* Literal.Number.Integer */
+.highlight .mo { color: #DFBFFF } /* Literal.Number.Oct */
+.highlight .sa { color: #F29E74 } /* Literal.String.Affix */
+.highlight .sb { color: #D5FF80 } /* Literal.String.Backtick */
+.highlight .sc { color: #D5FF80 } /* Literal.String.Char */
+.highlight .dl { color: #D5FF80 } /* Literal.String.Delimiter */
+.highlight .sd { color: #7E8AA1 } /* Literal.String.Doc */
+.highlight .s2 { color: #D5FF80 } /* Literal.String.Double */
+.highlight .se { color: #95E6CB } /* Literal.String.Escape */
+.highlight .sh { color: #D5FF80 } /* Literal.String.Heredoc */
+.highlight .si { color: #95E6CB } /* Literal.String.Interpol */
+.highlight .sx { color: #95E6CB } /* Literal.String.Other */
+.highlight .sr { color: #95E6CB } /* Literal.String.Regex */
+.highlight .s1 { color: #D5FF80 } /* Literal.String.Single */
+.highlight .ss { color: #DFBFFF } /* Literal.String.Symbol */
+.highlight .bp { color: #5CCFE6 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #FFD173 } /* Name.Function.Magic */
+.highlight .vc { color: #D4D2C8 } /* Name.Variable.Class */
+.highlight .vg { color: #D4D2C8 } /* Name.Variable.Global */
+.highlight .vi { color: #D4D2C8 } /* Name.Variable.Instance */
+.highlight .vm { color: #D4D2C8 } /* Name.Variable.Magic */
+.highlight .il { color: #DFBFFF } /* Literal.Number.Integer.Long */
+}

--- a/docs/_static/rtd_dark.css
+++ b/docs/_static/rtd_dark.css
@@ -9,6 +9,10 @@
  * Modified by Aloïs Dreyfus: 20200527-1037
  * Modified by Erik Kalkoken: 20220615
  * Modified by Nathan Dyer: 20230330
+ *
+ * NOTE: Dark mode styling for syntax highlighting is handled via a Pygments theme.
+ * Use the Makefile target `pygments-css` to update it.
+ *
  */
 
 :root {
@@ -32,10 +36,21 @@
 		color: #bf84d8;
 	}
 
-	pre {
-		background-color: #2d2d2d !important;
+	/* Code styling that's not covered by Pygments theme: regular pre-formatted text */
+	pre:not(.highlight) {
+		background-color: #1d2331 !important;
+		color: #d4d2c8 !important;
+		border: 1px solid #3c4354 !important;
+		border-radius: 4px;
+		padding: 0.4em 0.6em;
 	}
 
+	/* Code styling that's not covered by Pygments theme: inline code literals */
+	code.literal {
+		background-color: #1d2331 !important;
+		color: #d4d2c8 !important;
+		border: 1px solid #3c4354 !important;
+	}
 
 /*
 ** Vertical menu color overrides
@@ -102,11 +117,6 @@
 		color: #333333 !important;
 	}
 
-	code.literal {
-		background-color: #2d2d2d !important;
-		border: 1px solid #333333 !important;
-	}
-
 	.wy-nav-content-wrap {
 		background-color: rgba(0, 0, 0, 0.7) !important;
 	}
@@ -146,14 +156,6 @@
 
 	.wy-table-odd td, .wy-table-striped tr:nth-child(2n-1) td, .rst-content table.docutils:not(.field-list) tr:nth-child(2n-1) td {
 		background-color: #343131;
-	}
-
-	.highlight .m {
-		color: inherit
-	}
-
-	.highlight .nv {
-		color: #7dbdff
 	}
 
 	.rst-content .section .admonition ul {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,7 @@ html_logo = "../static/i/favicon.png"
 html_static_path = ['_static']
 html_css_files = [
     'rtd_dark.css',
+    'pygments_dark.css',
 ]
 
 # Add any extra paths that contain custom files (such as robots.txt or

--- a/extract_css.py
+++ b/extract_css.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Extract Pygments CSS for dark theme syntax highlighting.
+
+This script generates CSS for a specified Pygments theme and saves it
+to docs/_static/pygments_dark.css for use in the documentation.
+
+Usage:
+    python extract_css.py [style_name]
+
+Examples:
+    python extract_css.py lightbulb
+    python extract_css.py solarized-dark
+    python extract_css.py github-dark
+"""
+
+import sys
+from pathlib import Path
+from pygments.formatters import HtmlFormatter
+from pygments.styles import get_all_styles
+
+
+def extract_pygments_css(style_name, output_file=None):
+    """Extract Pygments CSS for the specified style, scoped to dark mode."""
+    if output_file is None:
+        output_file = Path("docs/_static/pygments_dark.css")
+
+    # Validate the style exists
+    available_styles = list(get_all_styles())
+    if style_name not in available_styles:
+        print(f"Error: Style '{style_name}' not found.")
+        print(f"Available styles: {', '.join(sorted(available_styles))}")
+        sys.exit(1)
+
+    # Generate CSS for the specified style
+    formatter = HtmlFormatter(style=style_name)
+    css_content = formatter.get_style_defs('.highlight')
+
+    # Wrap the CSS in a dark mode media query
+    scoped_css = f"""/* Pygments {style_name} theme - only applied in dark mode */
+@media (prefers-color-scheme: dark) {{
+{css_content}
+}}
+"""
+
+    # Write to file
+    output_file = Path(output_file)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(scoped_css)
+
+    print(f"Generated Pygments CSS for '{style_name}' theme (dark mode only): {output_file}")
+
+
+if __name__ == "__main__":
+    # Get style from command line argument or default to lightbulb
+    if len(sys.argv) > 1:
+        style_name = sys.argv[1]
+    else:
+        style_name = "lightbulb"
+
+    extract_pygments_css(style_name)


### PR DESCRIPTION
- Switch to lightbulb theme for code blocks
- Add extract_css.py script and Makefile target to update

Fixes #260 

Before:
<img width="1089" height="972" alt="image" src="https://github.com/user-attachments/assets/c6853eb6-6bb6-4bfc-a5e0-cf04af63f3b3" />

After:
<img width="1089" height="972" alt="image" src="https://github.com/user-attachments/assets/5775c784-cf57-4cc4-a0c5-759ee3140bd5" />


## AI note

Much of this change has been generated via Claude Code.

## Test plan

Compare light & dark mode on various pages in the docs before and after this change

## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits