### PR TITLE
Document Inbox's find-prod-deps.py script

### DIFF
--- a/docs/dependency_updates.rst
+++ b/docs/dependency_updates.rst
@@ -380,3 +380,12 @@ Exemptions can be specified in ``supply-chain/config.toml``:
 
 Note that within crates do review, you should still review all the code, regardless of what
 platform it is targeting.
+
+Identifying production dependencies in SecureDrop Inbox
+-------------------------------------------------------
+
+In the Inbox's package.json, the dependencies that are only used in the renderer are actually
+contained in the "devDependencies" field because they are bundled into the build.
+
+The ``find-prod-deps.py`` script can be used to get a real list of dependencies that
+are shipped in or compiled into the production build.


### PR DESCRIPTION
Follow-up to https://github.com/freedomofpress/securedrop-client/pull/3162.

## Test plan
<!--Any instructions the reviewer should reproduce? Otherwise, delete this section. -->
I couldn't find a better place for this so I just tacked it onto the bottom so it's at least mentioned, if you can think of a better spot please suggest!
## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits