### PR TITLE
Fix shell command examples

### DIFF
--- a/docs/contributor_guidelines.rst
+++ b/docs/contributor_guidelines.rst
@@ -214,14 +214,14 @@ How to Use mypy?
 ~~~~~~~~~~~~~~~~~
 
 ``make lint`` already checks for any error using the ``mypy`` tool. In case you want
-to have a local installation, you can do that using your Python 3 virtualenv.
+to have a local installation, you can do that using your Python 3 virtualenv:
 
 .. code:: shell
 
-    $ python3 -m venv ../.py3
-    $ source ../.py3/bin/activate
-    $ pip install mypy
-    $ mypy securedrop
+    python3 -m venv ../.py3
+    source ../.py3/bin/activate
+    pip install mypy
+    mypy securedrop
 
 Git History
 -----------

--- a/docs/dependency_updates.rst
+++ b/docs/dependency_updates.rst
@@ -330,16 +330,16 @@ We audit Rust crates using the `Cargo Vet <https://mozilla.github.io/cargo-vet/i
 
 .. code::
 
-   $ cargo install --locked cargo-vet
+   cargo install --locked cargo-vet
 
 Then you can audit both new and updated crates:
 
 .. code::
 
-   $ cargo vet diff $CRATE $OLD $NEW    # $CRATE has been updated from $OLD to $NEW.
-   $ cargo vet inspect $CRATE $VERSION  # $CRATE is entirely new at $VERSION.
+   cargo vet diff $CRATE $OLD $NEW    # $CRATE has been updated from $OLD to $NEW.
+   cargo vet inspect $CRATE $VERSION  # $CRATE is entirely new at $VERSION.
    [...]
-   $ cargo vet certify
+   cargo vet certify
 
 Running ``cargo vet suggest`` after updating or modifying dependencies will automatically
 provide you with the relevant ``diff`` and ``inspect`` commands to run.

--- a/docs/documentation_guidelines.rst
+++ b/docs/documentation_guidelines.rst
@@ -272,11 +272,11 @@ Glossary
 
 Text taken directly from a user interface is in **bold face**.
 
-    "Once you’re sure you have the right drive, click **Format Drive**."
+    "Once you're sure you have the right drive, click **Format Drive**."
 
 SecureDrop-specific `glossary <https://docs.securedrop.org/en/stable/glossary.html>`_ is in *italics*.
 
-    "To get started, you’ll need two Tails drives: one for the *Admin
+    "To get started, you'll need two Tails drives: one for the *Admin
     Workstation* and one for the *Secure Viewing Station*."
 
 When referring to virtual machines in the development environment, use

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -196,7 +196,7 @@ generate using this command in the base directory:
 
 .. code:: sh
 
-    $ LOCALES=en_US make translation-test
+    LOCALES=en_US make translation-test
 
 Inspect the screenshots in the directory ``securedrop/tests/pageslayout/screenshots/en_US``
 and make sure that their content corresponds to the expected version of the
@@ -208,7 +208,7 @@ You can now run this command to perform an upload:
 
 .. code:: sh
 
-    $ securedrop/upload-screenshots.py
+    securedrop/upload-screenshots.py
 
 If new screenshots were added as part of this run, make sure to associate them
 with relevant strings in Weblate, which you can do from the
@@ -364,9 +364,9 @@ know exists in the source strings. You can rebuild the index with:
 
 .. code:: sh
 
-      $ ssh debian@weblate.securedrop.org
-      $ cd /app/weblate
-      $ sudo docker-compose run weblate rebuild_index --all --clean
+      ssh debian@weblate.securedrop.org
+      cd /app/weblate
+      sudo docker-compose run weblate rebuild_index --all --clean
 
 Note that the new index may not be used right away. Some workers may
 still have the old index open. If the index is holding up translators

--- a/docs/making_pr.rst
+++ b/docs/making_pr.rst
@@ -45,7 +45,7 @@ If you create a new file, remember to add it with :code:`git add`.
 
   git add <new-file>
 
-Commit your changes, adding a description of what was added. If you’re not
+Commit your changes, adding a description of what was added. If you're not
 used to Git, the simplest way is to commit all modified files and add a
 description message of your changes in a single command like this:
 

--- a/docs/setup_development.rst
+++ b/docs/setup_development.rst
@@ -243,7 +243,7 @@ from the `Vagrant Downloads page`_ and then install it.
 .. _`GitHub #932`: https://github.com/freedomofpress/securedrop/pull/932
 .. _`GitHub #1381`: https://github.com/freedomofpress/securedrop/issues/1381
 
-.. warning:: We do not recommend installing vagrant-cachier. It destroys apt’s
+.. warning:: We do not recommend installing vagrant-cachier. It destroys apt's
             state unless the VMs are always shut down/rebooted with Vagrant,
             which conflicts with the tasks in the Ansible playbooks. The
             instructions in Vagrantfile that would enable vagrant-cachier are

--- a/docs/supported_languages.rst
+++ b/docs/supported_languages.rst
@@ -115,7 +115,7 @@ Then:
    SHOULD revoke support for *L* for *V3*.
 
         #. In consultation with Localization Lab and the Release
-           Manager, the Localization Manager MAY extend *L*’s probationary
+           Manager, the Localization Manager MAY extend *L*'s probationary
            period, for example if the `language census`_ indicates that revoking
            support for *L* would jeopardize the default locale for many
            instances, for especially high-traffic or high-profile instances,

--- a/docs/updategui_development.rst
+++ b/docs/updategui_development.rst
@@ -13,8 +13,8 @@ in a virtual environment. From the ``journalist_gui`` directory:
 
 ::
 
-    $ python3 -m venv .venv && source .venv/bin/activate
-    $ pip install --require-hashes -r dev-requirements.txt
+    python3 -m venv .venv && source .venv/bin/activate
+    pip install --require-hashes -r dev-requirements.txt
 
 The first command will create a virtual environment and activate it.
 The second command will install the dependencies, using the exact hashes
@@ -28,7 +28,7 @@ You can run the GUI via:
 
 ::
 
-    $ python3 SecureDropUpdater
+    python3 SecureDropUpdater
 
 Note that since the application expects to run in Tails, you should test its
 functionality in a Tails VM. You can follow the instructions in the
@@ -42,7 +42,7 @@ The design of the GUI is saved in the ``journalist_gui/mainwindow.ui`` file. To 
 
 ::
 
-    $ sudo apt install qtcreator python3-pyqt5
+    sudo apt install qtcreator python3-pyqt5
 
 
 
@@ -50,7 +50,7 @@ If we make any changes to the UI, we will have to use ``pyuic5`` command to upda
 
 ::
 
-    $ pyuic5 journalist_gui/mainwindow.ui -o journalist_gui/updaterUI.py
+    pyuic5 journalist_gui/mainwindow.ui -o journalist_gui/updaterUI.py
 
 
 Using Resources in the UI
@@ -77,7 +77,7 @@ command:
 
 ::
 
-    $ pyrcc5 journalist_gui/resources.qrc -o journalist_gui/resources_rc.py
+    pyrcc5 journalist_gui/resources.qrc -o journalist_gui/resources_rc.py
 
 
 
@@ -96,4 +96,4 @@ test cases or updating the old ones. You can run the tests using the following c
 
 ::
 
-    $ python3 test_gui.py
+    python3 test_gui.py

--- a/docs/workstation_development.rst
+++ b/docs/workstation_development.rst
@@ -1,7 +1,7 @@
 SecureDrop Workstation Development
 ==================================
 
-This project’s development requires different workflows for working on
+This project's development requires different workflows for working on
 provisioning components and working on submission-handling scripts.
 
 For developing salt states and other provisioning components, work is
@@ -15,7 +15,7 @@ top files there. In the ``dom0`` copy of this project:
   full installation.
 
 Note that ``make clone`` requires two environment variables to be set:
-``SECUREDROP_DEV_VM`` must be set to the name of the VM where you’ve
+``SECUREDROP_DEV_VM`` must be set to the name of the VM where you've
 been working on the code, the ``SECUREDROP_DEV_DIR`` should be set to
 the directory where the code is checked out on your development VM.
 
@@ -38,7 +38,7 @@ Configuration Tests
 
 These tests assert that expected scripts and configuration files are in
 the correct places across the VMs. These tests can be found in the
-``tests/`` directory. They can be run from the project’s root directory
+``tests/`` directory. They can be run from the project's root directory
 on ``dom0`` with:
 
 ::

--- a/docs/workstation_release_management.rst
+++ b/docs/workstation_release_management.rst
@@ -254,7 +254,7 @@ empty Signature field. Set up your environment (for prod you can use the
    %__gpg_sign_cmd %{__gpg} --no-verbose -u %{_gpg_name} --detach-sign %{__plaintext_filename} --output %{__signature_filename}
    EOF
 
-Now we’ll sign the RPM:
+Now we'll sign the RPM:
 
 ::
 

--- a/docs/workstation_setup.rst
+++ b/docs/workstation_setup.rst
@@ -39,7 +39,7 @@ have been properly applied. Finally, update all existing TemplateVMs:
    qubes-update-gui
 
 Select all VMs marked as **updates available**, then click **Next**.
-Once all updates have been applied, you’re ready to proceed. Choose the
+Once all updates have been applied, you're ready to proceed. Choose the
 environment that you wish to set up and then follow the applicable
 instructions:
 
@@ -92,7 +92,7 @@ be copied there from your development VM.
 
 .. include:: includes/dom0-warning.txt
 
-That process is a little tricky, but here’s one way to do it: assuming
+That process is a little tricky, but here's one way to do it: assuming
 this code is checked out in your ``sd-dev`` VM at
 ``/home/user/projects/securedrop-workstation``, run the following in
 ``dom0``:
@@ -105,15 +105,15 @@ this code is checked out in your ``sd-dev`` VM at
 that initial manual step, the code in your development VM may be copied
 into place on ``dom0`` by setting the ``SECUREDROP_DEV_VM`` and
 ``SECUREDROP_DEV_DIR`` environmental variables to reflect the VM and
-directory to which you’ve cloned this repo, and running ``make clone``
+directory to which you've cloned this repo, and running ``make clone``
 from the root of the project on ``dom0``:
 
 ::
 
-   [dom0]$ export SECUREDROP_DEV_VM=sd-dev    # set to your dev VM
-   [dom0]$ export SECUREDROP_DEV_DIR=/home/user/projects/securedrop-workstation    # set to your working directory
-   [dom0]$ cd ~/securedrop-workstation/
-   [dom0]$ make clone    # build RPM package and copy repo to dom0
+   export SECUREDROP_DEV_VM=sd-dev    # set to your dev VM
+   export SECUREDROP_DEV_DIR=/home/user/projects/securedrop-workstation    # set to your working directory
+   cd ~/securedrop-workstation/
+   make clone    # build RPM package and copy repo to dom0
 
 **NOTE:** The destination directory on ``dom0`` is not customizable; it
 must be ``securedrop-workstation`` in your home directory.
@@ -183,8 +183,8 @@ Then, in ``dom0``, clone the workstation again, to obtain these new files:
 
 ::
 
-   [dom0]$ cd ~/securedrop-workstation/
-   [dom0]$ make clone
+   cd ~/securedrop-workstation/
+   make clone
 
 
 Provision the VMs
@@ -214,9 +214,9 @@ dialog asking how to connect to Tor: you should be able to select the
 default option and continue. If you want to refer back to the
 provisioning log for a given VM, go to
 ``/var/log/qubes/mgmt-<vm name>.log`` in ``dom0``. You can also monitor
-logs as they’re being written via ``journalctl -ef``. This will display
-logs across the entire system so it can be noisy. It’s best used when
-you know what to look for, at least somewhat, or if you’re provisioning
+logs as they're being written via ``journalctl -ef``. This will display
+logs across the entire system so it can be noisy. It's best used when
+you know what to look for, at least somewhat, or if you're provisioning
 one VM at a time.
 
 When the installation process completes, a number of new VMs will be
@@ -229,7 +229,7 @@ When developing on the Workstation, make sure to edit files in
 ``sd-dev``, then copy them to dom0 via ``make clone && make dev`` to
 reinstall them. Any changes that you make to the
 ~/securedrop-workstation folder in dom0 will be overwritten during
-``make clone``. Similarly, any changes you make to e.g. ``/srv/salt/``
+``make clone``. Similarly, any changes you make to e.g. ``/srv/salt/``
 in dom0 will be overwritten by ``make dev``.
 
 Staging Environment
@@ -271,7 +271,7 @@ Download and install securedrop-workstation-dom0-config package
 Since ``dom0`` does not have network access, we will need to download
 the ``securedrop-workstation-dom0-config`` package in a Fedora-based VM.
 We can use the default Qubes-provisioned ``work`` VM. If you perform
-these changes in the ``work`` VM or another AppVM, they won’t persist
+these changes in the ``work`` VM or another AppVM, they won't persist
 across reboots (recommended).
 
 In a terminal in ``work``, run the following commands:
@@ -280,8 +280,8 @@ In a terminal in ``work``, run the following commands:
 
 ::
 
-   [user@work ~]$ wget https://raw.githubusercontent.com/freedomofpress/securedrop-workstation/master/sd-workstation/apt-test-pubkey.asc
-   [user@work ~]$ sudo rpmkeys --import apt-test-pubkey.asc
+   wget https://raw.githubusercontent.com/freedomofpress/securedrop-workstation/master/sd-workstation/apt-test-pubkey.asc
+   sudo rpmkeys --import apt-test-pubkey.asc
 
 2. Configure the test repository
 
@@ -299,7 +299,7 @@ contents:
 
 ::
 
-   [user@work ~]$ dnf download securedrop-workstation-dom0-config
+   dnf download securedrop-workstation-dom0-config
 
 The RPM file will be downloaded to your current working directory.
 
@@ -307,7 +307,7 @@ The RPM file will be downloaded to your current working directory.
 
 ::
 
-   [user@work ~]$ rpm -Kv securedrop-workstation-dom0-config-x.y.z-1.fc37.noarch.rpm
+   rpm -Kv securedrop-workstation-dom0-config-x.y.z-1.fc37.noarch.rpm
 
 The output should match the following, and return ``OK`` for all lines
 as follows:
@@ -329,7 +329,7 @@ its current value):
 
 ::
 
-   [dom0]$ qvm-run --pass-io work 'cat /home/user/securedrop-workstation-dom0-config-x.y.z-1.fc37.noarch.rpm' > securedrop-workstation.rpm
+   qvm-run --pass-io work 'cat /home/user/securedrop-workstation-dom0-config-x.y.z-1.fc37.noarch.rpm' > securedrop-workstation.rpm
    sudo dnf install securedrop-workstation.rpm
 
 The provisioning scripts and tools should now be in place, and you can
@@ -355,4 +355,4 @@ In a terminal in ``dom0``, run the following commands:
 
 ::
 
-   [dom0]$ sdw-admin --apply
+   sdw-admin --apply


### PR DESCRIPTION
This PR makes a few small edits in-line with the documentation guidelines (documented in this documentation itself, very meta). 

As per the guidelines, terminal commands/shell code should not begin with a `$` prompt when the commands are intended to by copy-pasted by the reader. This streamlines copy-pasting these commands. I've fixed all the occurrences of this I could find.  Including the prompt is appropriate when it's part of a block of example shell commands that includes the output. 

I also replaced the unicode character U+2019 (right single quotation) which was frequently used in place of the standard apostrophe `'` (a result of a European or possibly French-Canadian keyboard user I imagine). 

## Test plan
- [ ] CI happy
- [ ] visual inspection of changes
